### PR TITLE
Reproducible training entrypoint, evaluation metrics & CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,30 +5,17 @@ on:
   pull_request:
 
 jobs:
-  test:
+  tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
-
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
-
-      - name: Run tests (if present)
-        run: |
-          python - <<'PY'
-          import pathlib
-          tests = [p for p in pathlib.Path('.').rglob('test*.py')] + [p for p in pathlib.Path('.').rglob('*_test.py')]
-          if tests:
-              import pytest
-              raise SystemExit(pytest.main(['-q']))
-          print('No tests found; skipping.')
-          PY
+      - name: Run tests
+        run: python -m pytest

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ run:
 	$(PYTHON) application.py
 
 train:
-	$(PYTHON) -m src.pipeline.training_pipeline
+	$(PYTHON) -m src.train
 
 test:
-	$(PYTHON) -m unittest discover
+	$(PYTHON) -m pytest

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![CI](https://github.com/TumeloKonaite/Customer-Churning-Repo/actions/workflows/ci.yml/badge.svg)](https://github.com/TumeloKonaite/Customer-Churning-Repo/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
-[![Python](https://img.shields.io/badge/Python-3.9%2B-blue.svg)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://www.python.org/)
 [![Development Status](https://img.shields.io/badge/Status-Active-success.svg)](#development-status)
 [![Git Workflow](https://img.shields.io/badge/GitHub-Flow-blue.svg)](https://docs.github.com/en/get-started/quickstart/github-flow)
 
 ## Overview
-This Flask web application predicts customer churn using a pre-trained scikit-learn model. Users enter customer attributes via a simple UI, and the app returns whether the customer is likely to churn along with guidance for retention actions.
+This Flask web application predicts customer churn using a scikit-learn model. Users enter customer attributes via a simple UI, and the app returns whether the customer is likely to churn along with guidance for retention actions.
 
-The training pipeline is built in the notebook and saves a serialized artifact to `artifacts/model.pkl`.
+Training is notebook-independent via a pipeline and a CLI-style entrypoint. It saves model artifacts and metadata (including evaluation metrics and feature schema) under `artifacts/`.
 
 ## Features
 - User-friendly input form for customer data
@@ -67,12 +67,20 @@ make test    # run tests
 Visit: [http://127.0.0.1:5001](http://127.0.0.1:5001)
 
 ## Model Training
-- Notebook: `notebooks/Churning problem using multiple Classification Models.ipynb`
-- Output artifact: `artifacts/model.pkl`
+- Entrypoint: `src/train.py` (runs the pipeline and writes `artifacts/metadata.json`)
+- Pipeline: `src/pipeline/training_pipeline.py`
+- Output artifacts:
+  - `artifacts/model.pkl`
+  - `artifacts/metadata.json`
+  - `artifacts/schema.json`
+  - `artifacts/feature_columns.json`
 
 ## Project Structure
 ```
 Customer-Churning-Repo/
+├─ .github/
+│  └─ workflows/
+│     └─ ci.yml
 ├─ application.py
 ├─ artifacts/
 ├─ dataset/
@@ -84,9 +92,17 @@ Customer-Churning-Repo/
 │  └─ Churning problem using multiple Classification Models.ipynb
 ├─ src/
 │  ├─ components/
+│  ├─ metrics.py
 │  ├─ pipeline/
+│  ├─ decisioning.py
+│  ├─ train.py
 │  └─ utils.py
 ├─ templates/
+├─ tests/
+│  ├─ test_decisioning.py
+│  ├─ test_metrics.py
+│  └─ test_training_metadata.py
+├─ pyproject.toml
 ├─ requirements.txt
 ├─ Makefile
 └─ README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ scikit-learn
 matplotlib
 seaborn
 plotly
+pytest

--- a/src/components/data_transformation.py
+++ b/src/components/data_transformation.py
@@ -55,6 +55,10 @@ class DataTransformation:
 
             target_column_name = self.target_column_name
             feature_columns = self.numerical_columns + self.categorical_columns
+            feature_schema = [
+                {"name": col, "dtype": str(train_df[col].dtype)}
+                for col in feature_columns
+            ]
 
             missing_cols = [col for col in feature_columns if col not in train_df.columns]
             if missing_cols:
@@ -117,6 +121,7 @@ class DataTransformation:
             schema = {
                 "num_cols": self.numerical_columns,
                 "all_cols": feature_columns,
+                "feature_schema": feature_schema,
             }
             with open(self.data_transformation_config.schema_file_path, "w") as f:
                 json.dump(schema, f)

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,88 @@
+import numpy as np
+
+from sklearn.metrics import (
+    accuracy_score,
+    average_precision_score,
+    balanced_accuracy_score,
+    confusion_matrix,
+    f1_score,
+    precision_score,
+    recall_score,
+    roc_auc_score,
+)
+
+from src.exception import CustomException
+
+
+def _resolve_k(k, n_samples):
+    if isinstance(k, float):
+        if k <= 0 or k > 1:
+            raise ValueError("k as float must be in (0, 1].")
+        return max(1, int(np.ceil(n_samples * k)))
+    if isinstance(k, int):
+        if k <= 0 or k > n_samples:
+            raise ValueError("k as int must be in [1, n_samples].")
+        return k
+    raise ValueError("k must be float (fraction) or int (count).")
+
+
+def precision_at_k(y_true, y_score, k=0.1):
+    y_true = np.asarray(y_true)
+    y_score = np.asarray(y_score)
+    k_resolved = _resolve_k(k, len(y_true))
+    top_k_idx = np.argsort(-y_score)[:k_resolved]
+    return float(np.mean(y_true[top_k_idx]))
+
+
+def recall_at_k(y_true, y_score, k=0.1):
+    y_true = np.asarray(y_true)
+    positives = np.sum(y_true)
+    if positives == 0:
+        return 0.0
+    y_score = np.asarray(y_score)
+    k_resolved = _resolve_k(k, len(y_true))
+    top_k_idx = np.argsort(-y_score)[:k_resolved]
+    return float(np.sum(y_true[top_k_idx]) / positives)
+
+
+def lift_at_k(y_true, y_score, k=0.1):
+    y_true = np.asarray(y_true)
+    prevalence = np.mean(y_true)
+    if prevalence == 0:
+        return 0.0
+    return float(precision_at_k(y_true, y_score, k) / prevalence)
+
+
+def lift_curve(y_true, y_score, k_values=None):
+    if k_values is None:
+        k_values = [0.01, 0.05, 0.1, 0.2, 0.3]
+    curve = []
+    for k in k_values:
+        curve.append(
+            {
+                "k": float(k) if isinstance(k, float) else int(k),
+                "precision_at_k": precision_at_k(y_true, y_score, k),
+                "recall_at_k": recall_at_k(y_true, y_score, k),
+                "lift_at_k": lift_at_k(y_true, y_score, k),
+            }
+        )
+    return curve
+
+
+def compute_classification_metrics(y_true, y_score, threshold=0.5):
+    try:
+        y_true = np.asarray(y_true)
+        y_score = np.asarray(y_score)
+        y_pred = (y_score >= threshold).astype(int)
+        return {
+            "accuracy": float(accuracy_score(y_true, y_pred)),
+            "precision": float(precision_score(y_true, y_pred, zero_division=0)),
+            "recall": float(recall_score(y_true, y_pred, zero_division=0)),
+            "f1": float(f1_score(y_true, y_pred, zero_division=0)),
+            "balanced_accuracy": float(balanced_accuracy_score(y_true, y_pred)),
+            "roc_auc": float(roc_auc_score(y_true, y_score)),
+            "pr_auc": float(average_precision_score(y_true, y_score)),
+            "confusion_matrix": confusion_matrix(y_true, y_pred).tolist(),
+        }
+    except Exception as e:
+        raise CustomException(e, None)

--- a/src/pipeline/training_pipeline.py
+++ b/src/pipeline/training_pipeline.py
@@ -15,9 +15,11 @@ class TrainingPipeline:
             train_arr, test_arr, _ = DataTransformation().initiate_data_transformation(
                 train_data, test_data
             )
-            score = ModelTrainer().initiate_model_trainer(train_arr, test_arr)
+            training_result = ModelTrainer().initiate_model_trainer(
+                train_arr, test_arr
+            )
             logging.info("Training pipeline completed")
-            return score
+            return training_result
         except Exception as e:
             raise CustomException(e, sys)
 

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,84 @@
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+
+from src.pipeline.training_pipeline import TrainingPipeline
+
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+ARTIFACTS_DIR = os.path.join(PROJECT_ROOT, "artifacts")
+
+
+def _load_json(path, default):
+    if not os.path.exists(path):
+        return default
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def load_feature_schema(artifacts_dir):
+    schema_path = os.path.join(artifacts_dir, "schema.json")
+    feature_columns_path = os.path.join(artifacts_dir, "feature_columns.json")
+
+    schema = _load_json(schema_path, {})
+    feature_columns = _load_json(feature_columns_path, [])
+
+    return {
+        "raw_features": schema.get("feature_schema", []),
+        "input_columns": schema.get("all_cols", []),
+        "transformed_columns": feature_columns,
+    }
+
+
+def build_metadata(model_name, metrics, feature_schema, timestamp, model_path):
+    return {
+        "trained_at": timestamp,
+        "model_name": model_name,
+        "model_path": model_path,
+        "metrics": metrics,
+        "feature_schema": feature_schema,
+    }
+
+
+def write_metadata(artifacts_dir, metadata):
+    os.makedirs(artifacts_dir, exist_ok=True)
+    metadata_path = os.path.join(artifacts_dir, "metadata.json")
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+    return metadata_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Train churn model and write metadata artifacts."
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        default=ARTIFACTS_DIR,
+        help="Directory for training artifacts and metadata.json",
+    )
+    args = parser.parse_args()
+
+    training_result = TrainingPipeline().run()
+    model_name = training_result.get("best_model_name", "unknown-model")
+    metrics = training_result.get("metrics", {})
+    model_path = training_result.get("model_path", "")
+
+    feature_schema = load_feature_schema(args.artifacts_dir)
+    timestamp = datetime.now(timezone.utc).isoformat()
+    metadata = build_metadata(
+        model_name=model_name,
+        metrics=metrics,
+        feature_schema=feature_schema,
+        timestamp=timestamp,
+        model_path=model_path,
+    )
+
+    metadata_path = write_metadata(args.artifacts_dir, metadata)
+    print(json.dumps(metadata, indent=2))
+    print(f"Metadata written to {metadata_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_decisioning.py
+++ b/tests/test_decisioning.py
@@ -1,5 +1,3 @@
-import unittest
-
 from src.decisioning import (
     ACTION_COSTS,
     ACTION_DISCOUNT_CALL,
@@ -10,26 +8,22 @@ from src.decisioning import (
     recommended_action,
 )
 
-
-class TestDecisioning(unittest.TestCase):
-    def test_estimate_clv_proxy(self):
-        features = {"Balance": 1000.0, "Tenure": 5.0, "EstimatedSalary": 2000.0}
-        clv = estimate_clv(features)
-        self.assertAlmostEqual(clv, 1600.0, places=2)
-
-    def test_recommended_action_thresholds(self):
-        self.assertEqual(recommended_action(0.10), ACTION_NONE)
-        self.assertEqual(recommended_action(0.30), ACTION_EMAIL)
-        self.assertEqual(recommended_action(0.59), ACTION_EMAIL)
-        self.assertEqual(recommended_action(0.60), ACTION_DISCOUNT_CALL)
-
-    def test_expected_net_gain(self):
-        clv = 2000.0
-        p_churn = 0.4
-        action = ACTION_EMAIL
-        net_gain = expected_net_gain(p_churn, clv, ACTION_COSTS[action])
-        self.assertAlmostEqual(net_gain, 795.0, places=2)
+def test_estimate_clv_proxy():
+    features = {"Balance": 1000.0, "Tenure": 5.0, "EstimatedSalary": 2000.0}
+    clv = estimate_clv(features)
+    assert clv == 1600.0
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_recommended_action_thresholds():
+    assert recommended_action(0.10) == ACTION_NONE
+    assert recommended_action(0.30) == ACTION_EMAIL
+    assert recommended_action(0.59) == ACTION_EMAIL
+    assert recommended_action(0.60) == ACTION_DISCOUNT_CALL
+
+
+def test_expected_net_gain():
+    clv = 2000.0
+    p_churn = 0.4
+    action = ACTION_EMAIL
+    net_gain = expected_net_gain(p_churn, clv, ACTION_COSTS[action])
+    assert round(net_gain, 2) == 795.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from src.metrics import (
+    compute_classification_metrics,
+    lift_at_k,
+    lift_curve,
+    precision_at_k,
+    recall_at_k,
+)
+
+
+def test_compute_classification_metrics():
+    y_true = np.array([0, 0, 1, 1])
+    y_score = np.array([0.1, 0.4, 0.35, 0.8])
+
+    metrics = compute_classification_metrics(y_true=y_true, y_score=y_score)
+
+    assert round(metrics["accuracy"], 2) == 0.75
+    assert "roc_auc" in metrics
+    assert "pr_auc" in metrics
+    assert len(metrics["confusion_matrix"]) == 2
+
+
+def test_k_metrics_and_lift_curve():
+    y_true = np.array([1, 0, 1, 0, 1, 0])
+    y_score = np.array([0.9, 0.8, 0.7, 0.2, 0.1, 0.05])
+
+    assert precision_at_k(y_true, y_score, k=0.5) >= 0.5
+    assert recall_at_k(y_true, y_score, k=0.5) > 0
+    assert lift_at_k(y_true, y_score, k=0.5) > 0
+
+    curve = lift_curve(y_true, y_score, k_values=[0.5])
+    assert len(curve) == 1
+    assert "lift_at_k" in curve[0]

--- a/tests/test_training_metadata.py
+++ b/tests/test_training_metadata.py
@@ -1,0 +1,33 @@
+import json
+import os
+import tempfile
+from src.train import build_metadata, load_feature_schema, write_metadata
+
+
+def test_metadata_written():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        schema = {
+            "feature_schema": [{"name": "Age", "dtype": "int64"}],
+            "all_cols": ["Age"],
+        }
+        with open(os.path.join(tmpdir, "schema.json"), "w") as f:
+            json.dump(schema, f)
+        with open(os.path.join(tmpdir, "feature_columns.json"), "w") as f:
+            json.dump(["Age"], f)
+
+        feature_schema = load_feature_schema(tmpdir)
+        metadata = build_metadata(
+            model_name="TestModel",
+            metrics={"roc_auc": 0.8},
+            feature_schema=feature_schema,
+            timestamp="2025-01-01T00:00:00+00:00",
+            model_path=os.path.join(tmpdir, "model.pkl"),
+        )
+        metadata_path = write_metadata(tmpdir, metadata)
+
+        assert os.path.exists(metadata_path)
+        with open(metadata_path, "r") as f:
+            loaded = json.load(f)
+        assert loaded["model_name"] == "TestModel"
+        assert "feature_schema" in loaded
+        assert "metrics" in loaded


### PR DESCRIPTION

## Summary
This PR operationalizes training and evaluation with a dedicated CLI-style entrypoint, structured artifacts, and CI-backed tests.

## Key Changes
- Added `src/train.py` as the training entrypoint; writes `artifacts/metadata.json` with metrics and feature schema
- Structured training outputs from `ModelTrainer` and pipeline for traceable results
- Persisted feature schema (raw column names/types + transformed columns)
- Added business metrics (Precision@K / Recall@K / Lift curve) and classification metrics
- Introduced `src/metrics.py` and unit tests for metrics + metadata writing
- Added CI workflow to run tests on push/PR
- Switched tests to pytest and updated `make test`
- Updated README to reflect current repo structure and training artifacts

## How to Run
```bash
make train
make test
