### PR TITLE
Stabilize CI smoke and Windows tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
           pytest -v --ignore=tests/test_docker.py
 
       - name: Docker build
-        run: docker build -t churn-predictor:latest .
+        run: docker build --build-arg RUN_TRAINING=1 -t churn-predictor:latest .
 
       - name: Docker smoke test
         run: |
           # Start container
-          docker run -d --name churn -p 5000:5000 churn-predictor:latest
+          docker run -d --name churn -p 5000:5000 -e AUTO_TRAIN=0 churn-predictor:latest
 
           # Wait for container to be ready with better error handling
           echo "Waiting for service to be ready..."

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,12 @@ PYTHON ?= python
 IMAGE_NAME = churn-predictor
 PORT = 5001
 
+ifeq ($(OS),Windows_NT)
+SMOKE_CMD = powershell -NoProfile -ExecutionPolicy Bypass -File scripts/smoke.ps1
+else
+SMOKE_CMD = sh scripts/smoke.sh
+endif
+
 .PHONY: run train test smoke clean docker-* install lint
 
 # Development commands
@@ -18,7 +24,7 @@ test:
 	$(PYTHON) -m pytest
 
 smoke:
-	sh scripts/smoke.sh
+	$(SMOKE_CMD)
 
 lint:
 	$(PYTHON) -m flake8 .

--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ make run     # start the web app locally
 make test    # run tests
 ```
 
+**Windows PowerShell (no make installed)**
+```powershell
+python -m src.train
+python application.py
+python -m pytest
+```
+
 ### 3. Open the app
 Visit: http://localhost:5001
 
@@ -105,6 +112,18 @@ docker run -p 5001:5001 churn-predictor
 ```
 
 Visit http://localhost:5001 to access the application.
+
+### Smoke Test
+```bash
+# macOS / Linux
+BASE_URL=http://localhost:5001 make smoke
+```
+
+```powershell
+# Windows PowerShell
+$env:BASE_URL="http://localhost:5001"
+make smoke
+```
 
 ## API Contract
 

--- a/application.py
+++ b/application.py
@@ -42,18 +42,22 @@ NUMERIC_FIELDS = {
     "EstimatedSalary": float,
 }
 
+PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
+ARTIFACTS_DIR = os.path.join(PROJECT_ROOT, "artifacts")
+
 REQUIRED_ARTIFACTS = [
-    "artifacts/schema.json",
-    "artifacts/preprocessor.pkl",
-    "artifacts/encoder.pkl",
-    "artifacts/model.pkl",
+    os.path.join(ARTIFACTS_DIR, "schema.json"),
+    os.path.join(ARTIFACTS_DIR, "preprocessor.pkl"),
+    os.path.join(ARTIFACTS_DIR, "encoder.pkl"),
+    os.path.join(ARTIFACTS_DIR, "model.pkl"),
 ]
 
 
 def load_metadata():
     """Load model metadata if present."""
+    metadata_path = os.path.join(ARTIFACTS_DIR, "metadata.json")
     try:
-        with open("artifacts/metadata.json", "r") as f:
+        with open(metadata_path, "r") as f:
             return json.load(f)
     except FileNotFoundError:
         return {"training_date": "unknown", "model_name": "churn_predictor"}

--- a/scripts/smoke.ps1
+++ b/scripts/smoke.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = "Stop"
+
+$baseUrl = $env:BASE_URL
+if ([string]::IsNullOrWhiteSpace($baseUrl)) {
+    $baseUrl = "http://localhost:5001"
+}
+
+$healthUrl = "$baseUrl/health"
+$predictUrl = "$baseUrl/api/predict"
+
+Write-Host "Smoke test against $baseUrl"
+
+$healthResponse = $null
+try {
+    $healthResponse = Invoke-RestMethod -Uri $healthUrl -Method Get
+} catch {
+    Write-Error "Health check failed: $($_.Exception.Message)"
+    exit 1
+}
+
+if ($healthResponse.status -ne "healthy") {
+    Write-Error "Health check did not return status=healthy."
+    $healthResponse | ConvertTo-Json -Depth 10 | Write-Host
+    exit 1
+}
+
+if (-not $healthResponse.model_loaded) {
+    Write-Error "Health check indicates model artifacts are not loaded."
+    $healthResponse | ConvertTo-Json -Depth 10 | Write-Host
+    exit 1
+}
+
+$payload = @{
+    CreditScore     = 619
+    Geography       = "France"
+    Gender          = "Female"
+    Age             = 42
+    Tenure          = 2
+    Balance         = 0
+    NumOfProducts   = 1
+    HasCrCard       = 1
+    IsActiveMember  = 1
+    EstimatedSalary = 101348.88
+} | ConvertTo-Json
+
+$predictResponse = $null
+try {
+    $predictResponse = Invoke-RestMethod -Uri $predictUrl -Method Post -ContentType "application/json" -Body $payload
+} catch {
+    Write-Error "Predict request failed: $($_.Exception.Message)"
+    exit 1
+}
+
+if ($null -eq $predictResponse.p_churn) {
+    Write-Error "Predict response missing p_churn."
+    $predictResponse | ConvertTo-Json -Depth 10 | Write-Host
+    exit 1
+}
+
+Write-Host "Smoke test passed."

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -25,6 +25,11 @@ if ! grep -q '"status"[[:space:]]*:[[:space:]]*"healthy"' "$health_body"; then
   cat "$health_body"
   exit 1
 fi
+if ! grep -q '"model_loaded"[[:space:]]*:[[:space:]]*true' "$health_body"; then
+  echo "Health check indicates model artifacts are not loaded."
+  cat "$health_body"
+  exit 1
+fi
 
 predict_status="$(curl -sS -o "$predict_body" -w "%{http_code}" \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
Make CI/Docker smoke tests deterministic by ensuring artifacts are present and verifying readiness before predict calls, plus add Windows-friendly smoke tooling and docs.

## Why
The MVP readiness review flagged CI instability: `/api/predict` could fail if artifacts weren’t baked into the image or not loaded at startup. This PR removes that class of failure and makes smoke tests assert true readiness.

## Changes
- Resolve artifact paths relative to the app file to avoid cwd-dependent failures.
- Strengthen smoke checks to require `model_loaded=true` before calling `/api/predict`.
- Build Docker images in CI with `RUN_TRAINING=1` and run with `AUTO_TRAIN=0` to fail fast if artifacts are missing.
- Add PowerShell smoke script and Makefile detection for Windows.
- Document PowerShell quickstart + smoke steps in README.

## Testing
- PowerShell smoke test against Docker container (passed).

Closes #36
