### PR TITLE
Clarify deps and consolidate entrypoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ else
 SMOKE_CMD = sh scripts/smoke.sh
 endif
 
-.PHONY: run train test smoke clean docker-* install lint
+.PHONY: run train test smoke clean docker-* install lint reqs
 
 # Development commands
 install:
@@ -22,6 +22,9 @@ train:
 
 test:
 	$(PYTHON) -m pytest
+
+reqs:
+	uv pip compile pyproject.toml -o requirements.txt
 
 smoke:
 	$(SMOKE_CMD)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ All assumptions and thresholds are documented in `src/decisioning.py`.
 The table below uses the same formulas and action costs defined in `src/decisioning.py`.
 
 | Scenario | p_churn | Balance | Tenure | EstimatedSalary | CLV (proxy) | Action | Action Cost | Expected Net Gain |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| --- | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: |
 | Low risk | 0.20 | 10,000 | 5 | 50,000 | 13,000 | No action | 0 | 2,600 |
 | Medium risk | 0.45 | 2,500 | 2 | 60,000 | 5,300 | Retention email | 5 | 2,380 |
 | High risk | 0.75 | 15,000 | 8 | 80,000 | 19,000 | Discount or retention call | 50 | 14,200 |
@@ -71,7 +71,10 @@ pip install -r requirements.txt
 make train   # train model and save to artifacts/
 make run     # start the web app locally
 make test    # run tests
+make reqs    # regenerate requirements.txt from pyproject.toml
 ```
+
+Canonical app entrypoint: `application.py` (with `main.py` as a thin shim).
 
 **Windows PowerShell (no make installed)**
 ```powershell
@@ -95,6 +98,10 @@ Visit: http://localhost:5001
 **Note:** Large binary artifacts are not committed. Example files for docs live in:
 - `artifacts/sample_metadata.json`
 - `artifacts/schema.example.json`
+
+## Dependencies
+`pyproject.toml` is the source of truth for dependencies (with `uv.lock` for locking).
+`requirements.txt` is generated for deployment and can be regenerated via `make reqs`.
 
 ## Docker Quick Start
 

--- a/application.py
+++ b/application.py
@@ -296,8 +296,12 @@ def predict_datapoint():
     )
 
 
-if __name__ == "__main__":
+def run_app():
     # Binding to 0.0.0.0 is required for container access
     debug = os.getenv("FLASK_DEBUG", "0") == "1"
     port = int(os.getenv("PORT", "5001"))
     app.run(host="0.0.0.0", port=port, debug=debug)
+
+
+if __name__ == "__main__":
+    run_app()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
-def main():
-    print("Hello from customer-churning-repo!")
+from application import run_app
 
 
 if __name__ == "__main__":
-    main()
+    run_app()


### PR DESCRIPTION
## Summary
Clarify dependency source of truth, add deterministic requirements generation, consolidate app entrypoints, and polish the ROI table.

## Changes
- Added `run_app()` in `application.py` and made `main.py` a thin shim.
- Added `make reqs` to generate `requirements.txt` from `pyproject.toml` via `uv`.
- Updated README with dependency guidance, entrypoint note, and improved ROI table formatting.

## Why
- Reduces confusion about which files to run and how dependencies are managed.
- Makes the ROI example easier to read.
- Keeps deployment requirements reproducible.

## Testing
Not run (doc/entrypoint/Makefile changes only).

Closes #44
