### PR TITLE
Harden /api/predict when probability is unavailable

### DIFF
--- a/application.py
+++ b/application.py
@@ -166,9 +166,12 @@ def predict_api():
                 "EstimatedSalary": float(data["EstimatedSalary"]),
             }
         )
-        action = recommended_action(churn_probability)
-        action_cost = float(ACTION_COSTS.get(action, 0.0))
-        net_gain = expected_net_gain(churn_probability, clv, action_cost)
+        action = None
+        net_gain = None
+        if churn_probability is not None:
+            action = recommended_action(churn_probability)
+            action_cost = float(ACTION_COSTS.get(action, 0.0))
+            net_gain = expected_net_gain(churn_probability, clv, action_cost)
 
         metadata = load_metadata()
 

--- a/tests/test_api_predict.py
+++ b/tests/test_api_predict.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+import application
+
+
+def test_predict_proba_missing_returns_null_decisioning_fields(monkeypatch):
+    class FakeCustomData:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def get_data_as_data_frame(self):
+            return object()
+
+    class FakePredictPipeline:
+        def predict(self, features):
+            return np.array([0]), None
+
+    monkeypatch.setattr(application, "artifacts_ready", lambda: True)
+    monkeypatch.setattr(application, "CustomData", FakeCustomData)
+    monkeypatch.setattr(application, "PredictPipeline", FakePredictPipeline)
+    monkeypatch.setattr(
+        application,
+        "load_metadata",
+        lambda: {"model_name": "test_model", "version": "9.9.9"},
+    )
+
+    client = application.app.test_client()
+    payload = {
+        "CreditScore": 619,
+        "Geography": "France",
+        "Gender": "Female",
+        "Age": 42,
+        "Tenure": 2,
+        "Balance": 0,
+        "NumOfProducts": 1,
+        "HasCrCard": 1,
+        "IsActiveMember": 1,
+        "EstimatedSalary": 101348.88,
+    }
+
+    response = client.post("/api/predict", json=payload)
+
+    assert response.status_code == 200
+    body = response.get_json()
+
+    assert body["status"] == "success"
+    assert body["predicted_label"] == 0
+    assert "clv" in body
+    assert body["clv"] is not None
+
+    assert "p_churn" in body
+    assert body["p_churn"] is None
+    assert "recommended_action" in body
+    assert body["recommended_action"] is None
+    assert "net_gain" in body
+    assert body["net_gain"] is None
+
+    assert body["model_name"] == "test_model"
+    assert body["model_version"] == "9.9.9"


### PR DESCRIPTION

## Summary

Hardened the `/api/predict` endpoint to safely handle cases where the model does not expose `predict_proba`.

This prevents a real failure path while preserving a **stable response contract**.

---

## What Changed

### 🔧 Endpoint Hardening

**`application.py` (line 169)**

- `recommended_action` and `net_gain` are initialized to `None`
- Decisioning logic is executed **only if** `churn_probability is not None`
- If probability is missing:
  - `p_churn = null`
  - `recommended_action = null`
  - `net_gain = null`

### 📦 Stable Response Schema

Response keys are **always present**, regardless of probability availability:

- `predicted_label`
- `clv`
- `p_churn`
- `recommended_action`
- `net_gain`
- `metadata`
  - `model_name`
  - `model_version`

When probability is unavailable, decisioning fields become JSON `null`, not omitted.

---

## Tests Added

### `tests/test_api_predict.py::test_predict_proba_missing_returns_null_decisioning_fields`

**Test behavior:**

- Monkeypatches `PredictPipeline.predict(...)`
- Forces return:

  ```python
  (np.array([0]), None)