### PR TITLE
Add batch prediction contract validation service

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,1 @@
+# Shared services package for API/business logic extraction.

--- a/src/services/prediction_service.py
+++ b/src/services/prediction_service.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from typing import Any
+import re
+
+REQUIRED_FIELDS = [
+    "CreditScore",
+    "Geography",
+    "Gender",
+    "Age",
+    "Tenure",
+    "Balance",
+    "NumOfProducts",
+    "HasCrCard",
+    "IsActiveMember",
+    "EstimatedSalary",
+]
+
+NUMERIC_FIELDS = {
+    "CreditScore": float,
+    "Age": float,
+    "Tenure": float,
+    "Balance": float,
+    "NumOfProducts": float,
+    "HasCrCard": float,
+    "IsActiveMember": float,
+    "EstimatedSalary": float,
+}
+
+VALID_BATCH_MODES = {"fail_fast", "partial"}
+MAX_BATCH_SIZE = 100
+
+_MISSING_FIELD_RE = re.compile(r"^Missing required field: (?P<field>.+)$")
+_NUMERIC_FIELD_RE = re.compile(r"^Field '(?P<field>[^']+)' must be a number")
+
+
+def validate_record(record: Any) -> tuple[bool, list[str], dict | None]:
+    """Validate one prediction record using single-record API semantics."""
+    if not isinstance(record, dict):
+        return False, ["Record must be a JSON object"], None
+
+    missing = [k for k in REQUIRED_FIELDS if k not in record or record.get(k) in (None, "")]
+    if missing:
+        return False, [f"Missing required field: {k}" for k in missing], None
+
+    coerced_record = dict(record)
+    cast_errors = []
+    for key, caster in NUMERIC_FIELDS.items():
+        try:
+            coerced_record[key] = caster(record.get(key))
+        except Exception:
+            cast_errors.append(f"Field '{key}' must be a number (got {record.get(key)!r})")
+
+    if cast_errors:
+        return False, cast_errors, None
+
+    return True, [], coerced_record
+
+
+def validate_batch(records: list[dict], mode: str) -> dict:
+    if mode not in VALID_BATCH_MODES:
+        raise ValueError(f"Unsupported batch mode: {mode}")
+
+    result = {
+        "valid_rows": [],
+        "errors": [],
+        "row_map": {},
+    }
+
+    for row_index, record in enumerate(records):
+        ok, errors, coerced_record = validate_record(record)
+        if ok:
+            valid_index = len(result["valid_rows"])
+            result["valid_rows"].append(coerced_record)
+            result["row_map"][valid_index] = row_index
+            continue
+
+        for error_message in errors:
+            error_item = {
+                "row_index": row_index,
+                "message": error_message,
+            }
+
+            missing_match = _MISSING_FIELD_RE.match(error_message)
+            numeric_match = _NUMERIC_FIELD_RE.match(error_message)
+            if missing_match:
+                error_item["field"] = missing_match.group("field")
+            elif numeric_match:
+                error_item["field"] = numeric_match.group("field")
+
+            result["errors"].append(error_item)
+
+        if mode == "fail_fast":
+            break
+
+    return result

--- a/tests/test_batch_predict_contract.py
+++ b/tests/test_batch_predict_contract.py
@@ -1,0 +1,93 @@
+import application
+from src.services.prediction_service import MAX_BATCH_SIZE
+
+
+def valid_record():
+    return {
+        "CreditScore": 619,
+        "Geography": "France",
+        "Gender": "Female",
+        "Age": 42,
+        "Tenure": 2,
+        "Balance": 0,
+        "NumOfProducts": 1,
+        "HasCrCard": 1,
+        "IsActiveMember": 1,
+        "EstimatedSalary": 101348.88,
+    }
+
+
+def test_batch_contract_requires_records():
+    client = application.app.test_client()
+
+    response = client.post("/api/predict/batch", json={})
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["status"] == "error"
+    assert "records" in body["message"]
+    assert body["contract_version"] == "v1"
+
+
+def test_batch_over_limit_returns_413():
+    client = application.app.test_client()
+    payload = {
+        "records": [valid_record() for _ in range(MAX_BATCH_SIZE + 1)],
+        "options": {"mode": "partial"},
+    }
+
+    response = client.post("/api/predict/batch", json=payload)
+
+    assert response.status_code == 413
+    body = response.get_json()
+    assert body["status"] == "error"
+    assert body["contract_version"] == "v1"
+
+
+def test_batch_mode_fail_fast_rejects_invalid():
+    client = application.app.test_client()
+    invalid = valid_record()
+    invalid.pop("Age")
+    payload = {
+        "records": [valid_record(), invalid, valid_record()],
+        "options": {"mode": "fail_fast"},
+    }
+
+    response = client.post("/api/predict/batch", json=payload)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["status"] == "error"
+    assert body["mode"] == "fail_fast"
+    assert len(body["errors"]) == 1
+    assert body["errors"][0]["row_index"] == 1
+    assert body["errors"][0]["field"] == "Age"
+    assert body["errors"][0]["message"] == "Missing required field: Age"
+
+
+def test_batch_mode_partial_collects_errors():
+    client = application.app.test_client()
+    missing_age = valid_record()
+    missing_age.pop("Age")
+    bad_balance = valid_record()
+    bad_balance["Balance"] = "not-a-number"
+    payload = {
+        "records": [valid_record(), missing_age, bad_balance],
+        "options": {"mode": "partial"},
+    }
+
+    response = client.post("/api/predict/batch", json=payload)
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "partial"
+    assert body["contract_version"] == "v1"
+    assert body["mode"] == "partial"
+    assert len(body["valid_rows"]) == 1
+    assert len(body["errors"]) == 2
+    assert [err["row_index"] for err in body["errors"]] == [1, 2]
+    assert body["errors"][0]["field"] == "Age"
+    assert body["errors"][0]["message"] == "Missing required field: Age"
+    assert body["errors"][1]["field"] == "Balance"
+    assert body["errors"][1]["message"].startswith("Field 'Balance' must be a number")
+    assert body["row_map"]["0"] == 0


### PR DESCRIPTION


## Summary

This PR introduces a shared prediction service layer and implements the **batch prediction API contract with validation-only behavior**.

It defines and locks in:

- Batch request/response schema
- Validation semantics (`fail_fast` vs `partial`)
- MAX_BATCH_SIZE enforcement
- Structured row-level error reporting
- Stable response envelope (`contract_version: "v1"`)

⚠️ No batch prediction execution is implemented in this PR (that is handled in PR 3).

---

## What Was Added

### 1️⃣ Shared Validation Service

**New module:**
