### PR TITLE
Implement batch prediction service execution

### DIFF
--- a/tests/test_batch_predict_contract.py
+++ b/tests/test_batch_predict_contract.py
@@ -1,4 +1,5 @@
 import application
+import src.services.prediction_service as prediction_service
 from src.services.prediction_service import MAX_BATCH_SIZE
 
 
@@ -15,6 +16,32 @@ def valid_record():
         "IsActiveMember": 1,
         "EstimatedSalary": 101348.88,
     }
+
+
+class FakePredictPipeline:
+    call_count = 0
+    last_df = None
+    labels = []
+    probabilities = []
+
+    def predict(self, df):
+        FakePredictPipeline.call_count += 1
+        FakePredictPipeline.last_df = df.copy()
+        return list(FakePredictPipeline.labels), list(FakePredictPipeline.probabilities)
+
+
+def patch_batch_execution(monkeypatch, *, labels, probabilities):
+    FakePredictPipeline.call_count = 0
+    FakePredictPipeline.last_df = None
+    FakePredictPipeline.labels = list(labels)
+    FakePredictPipeline.probabilities = list(probabilities)
+    monkeypatch.setattr(prediction_service, "PredictPipeline", FakePredictPipeline)
+    monkeypatch.setattr(application, "artifacts_ready", lambda: True)
+    monkeypatch.setattr(
+        prediction_service,
+        "_load_model_metadata",
+        lambda: {"model_name": "test-model", "model_version": "test-version"},
+    )
 
 
 def test_batch_contract_requires_records():
@@ -44,7 +71,8 @@ def test_batch_over_limit_returns_413():
     assert body["contract_version"] == "v1"
 
 
-def test_batch_mode_fail_fast_rejects_invalid():
+def test_batch_mode_fail_fast_rejects_invalid(monkeypatch):
+    patch_batch_execution(monkeypatch, labels=[0], probabilities=[0.1])
     client = application.app.test_client()
     invalid = valid_record()
     invalid.pop("Age")
@@ -58,21 +86,26 @@ def test_batch_mode_fail_fast_rejects_invalid():
     assert response.status_code == 400
     body = response.get_json()
     assert body["status"] == "error"
-    assert body["mode"] == "fail_fast"
+    assert body["results"] == []
     assert len(body["errors"]) == 1
     assert body["errors"][0]["row_index"] == 1
     assert body["errors"][0]["field"] == "Age"
     assert body["errors"][0]["message"] == "Missing required field: Age"
+    assert set(body) == {"status", "results", "errors", "summary", "metadata", "timestamp"}
+    assert FakePredictPipeline.call_count == 0
+    assert body["summary"]["mode"] == "fail_fast"
+    assert body["metadata"]["model_version"] == "test-version"
 
 
-def test_batch_mode_partial_collects_errors():
+def test_batch_mode_partial_predicts_once_and_maps_indices(monkeypatch):
+    patch_batch_execution(monkeypatch, labels=[1, 0], probabilities=[0.91, 0.08])
     client = application.app.test_client()
     missing_age = valid_record()
     missing_age.pop("Age")
-    bad_balance = valid_record()
-    bad_balance["Balance"] = "not-a-number"
+    trailing_valid = valid_record()
+    trailing_valid["Age"] = 50
     payload = {
-        "records": [valid_record(), missing_age, bad_balance],
+        "records": [valid_record(), missing_age, trailing_valid],
         "options": {"mode": "partial"},
     }
 
@@ -81,13 +114,68 @@ def test_batch_mode_partial_collects_errors():
     assert response.status_code == 200
     body = response.get_json()
     assert body["status"] == "partial"
-    assert body["contract_version"] == "v1"
-    assert body["mode"] == "partial"
-    assert len(body["valid_rows"]) == 1
-    assert len(body["errors"]) == 2
-    assert [err["row_index"] for err in body["errors"]] == [1, 2]
+    assert set(body) == {"status", "results", "errors", "summary", "metadata", "timestamp"}
+    assert FakePredictPipeline.call_count == 1
+    assert list(FakePredictPipeline.last_df.index) == [0, 1]
+    assert len(FakePredictPipeline.last_df) == 2
+    assert len(body["results"]) == 2
+    assert [item["index"] for item in body["results"]] == [0, 2]
+    assert [item["predicted_label"] for item in body["results"]] == [1, 0]
+    assert [item["p_churn"] for item in body["results"]] == [0.91, 0.08]
+    assert len(body["errors"]) == 1
+    assert [err["row_index"] for err in body["errors"]] == [1]
     assert body["errors"][0]["field"] == "Age"
     assert body["errors"][0]["message"] == "Missing required field: Age"
-    assert body["errors"][1]["field"] == "Balance"
-    assert body["errors"][1]["message"].startswith("Field 'Balance' must be a number")
-    assert body["row_map"]["0"] == 0
+    assert body["summary"]["mode"] == "partial"
+    assert body["summary"]["total_records"] == 3
+    assert body["summary"]["valid_records"] == 2
+    assert body["summary"]["invalid_records"] == 1
+    assert body["metadata"]["model_name"] == "test-model"
+    assert body["metadata"]["model_version"] == "test-version"
+
+
+def test_batch_all_valid_default_mode_predicts_once(monkeypatch):
+    patch_batch_execution(monkeypatch, labels=[0, 1], probabilities=[0.12, 0.87])
+    client = application.app.test_client()
+    payload = {
+        "records": [valid_record(), valid_record()],
+    }
+
+    response = client.post("/api/predict/batch", json=payload)
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "success"
+    assert body["errors"] is None
+    assert [item["index"] for item in body["results"]] == [0, 1]
+    assert set(body) == {"status", "results", "errors", "summary", "metadata", "timestamp"}
+    assert FakePredictPipeline.call_count == 1
+    assert body["summary"]["mode"] == "fail_fast"
+    assert body["summary"]["valid_records"] == 2
+    assert body["summary"]["invalid_records"] == 0
+
+
+def test_batch_partial_with_no_valid_rows_returns_failed_and_skips_model(monkeypatch):
+    patch_batch_execution(monkeypatch, labels=[], probabilities=[])
+    client = application.app.test_client()
+    invalid_one = valid_record()
+    invalid_one.pop("Age")
+    invalid_two = valid_record()
+    invalid_two["Balance"] = "bad"
+    payload = {
+        "records": [invalid_one, invalid_two],
+        "options": {"mode": "partial"},
+    }
+
+    response = client.post("/api/predict/batch", json=payload)
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "failed"
+    assert body["results"] == []
+    assert FakePredictPipeline.call_count == 0
+    assert len(body["errors"]) == 2
+    assert [err["row_index"] for err in body["errors"]] == [0, 1]
+    assert body["summary"]["total_records"] == 2
+    assert body["summary"]["valid_records"] == 0
+    assert body["summary"]["invalid_records"] == 2


### PR DESCRIPTION
## ✅ Issue Closed — PR 3: Batch Prediction Execution (Detinistic + Single Model Call)

### Summary

Implemented end-to-end batch prediction execution using a single DataFrame build and exactly one call to `PredictPipeline.predict`, with deterministic index mapping back to original input records.

This PR fully satisfies the issue requirements.

---

### What Was Implemented

#### 1️⃣ Service Layer Execution

Added `predict_batch_records(records, options)` in `prediction_service.py`:

- Validates records and options (reuses `validate_batch(...)`)
- Builds **one** `pandas.DataFrame` from valid rows only
- Calls `PredictPipeline.predict(df)` **exactly once**
- Maps outputs deterministically using `results[].index`
- Returns stable response envelope:
  - `status`
  - `results`
  - `errors`
  - `summary`
  - `metadata` (includes `model_name`, `model_version`)
  - `timestamp`

---

#### 2️⃣ Deterministic Mapping

- Each prediction result includes:
  ```json
  {
    "index": <original_input_position>,
    "predicted_label": <int>,
    "p_churn": <float|null>
  }