### PR TITLE
Add retention writer tools and smoke tests

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,5 +1,13 @@
 from .email_manager import emailer_agent, handoff_description
 from .formatter_agents import html_converter, html_tool, subject_tool, subject_writer
+from .retention_writers import (
+    ConciseRetentionWriter,
+    SeriousRetentionWriter,
+    WittyRetentionWriter,
+    write_retention_email_concise,
+    write_retention_email_serious,
+    write_retention_email_witty,
+)
 from .tools_email import send_email_html, send_email_text
 
 __all__ = [
@@ -11,4 +19,10 @@ __all__ = [
     "subject_tool",
     "html_converter",
     "html_tool",
+    "SeriousRetentionWriter",
+    "WittyRetentionWriter",
+    "ConciseRetentionWriter",
+    "write_retention_email_serious",
+    "write_retention_email_witty",
+    "write_retention_email_concise",
 ]

--- a/src/agents/retention_writers.py
+++ b/src/agents/retention_writers.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+try:
+    from agents import Agent, Runner, function_tool
+except Exception:
+    @dataclass(slots=True)
+    class Agent:  # type: ignore[override]
+        name: str
+        instructions: str
+
+    @dataclass(slots=True)
+    class _RunnerResult:
+        final_output: str
+
+    class Runner:  # type: ignore[override]
+        @staticmethod
+        def run_sync(agent: Agent, input: str) -> _RunnerResult:  # noqa: ARG004
+            return _RunnerResult(final_output=input)
+
+    def function_tool(func):
+        return func
+
+
+TOOL_DESCRIPTION = "Write a cold sales/retention email"
+
+_SUBJECT_PREFIX_RE = re.compile(r"^\s*subject\s*:\s*", re.IGNORECASE)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _final_output_to_text(result: Any) -> str:
+    final_output = getattr(result, "final_output", result)
+    if final_output is None:
+        return ""
+    return str(final_output).strip()
+
+
+def _sanitize_plain_text_body(text: str) -> str:
+    if not text:
+        return ""
+
+    without_html = _HTML_TAG_RE.sub("", text)
+    lines: list[str] = []
+    first_content_line = True
+
+    for raw_line in without_html.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if lines and lines[-1]:
+                lines.append("")
+            continue
+        if first_content_line:
+            line = _SUBJECT_PREFIX_RE.sub("", line).strip()
+            first_content_line = False
+        lines.append(line)
+
+    return "\n".join(lines).strip()
+
+
+def _normalize_prompt(prompt: str) -> str:
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ValueError("'prompt' must be a non-empty string")
+    return prompt.strip()
+
+
+def _merge_context(
+    context: dict[str, Any] | None,
+    *,
+    company_name: str | None = None,
+    from_name: str | None = None,
+    from_email: str | None = None,
+    recipient_name: str | None = None,
+) -> dict[str, Any] | None:
+    merged: dict[str, Any] = {}
+    if context is not None:
+        if not isinstance(context, dict):
+            raise ValueError("'context' must be a dictionary when provided")
+        merged.update(context)
+
+    optionals = {
+        "company_name": company_name,
+        "from_name": from_name,
+        "from_email": from_email,
+        "recipient_name": recipient_name,
+    }
+    for key, value in optionals.items():
+        if value is None:
+            continue
+        value_text = str(value).strip()
+        if value_text:
+            merged[key] = value_text
+
+    return merged or None
+
+
+def _compose_input(prompt: str, context: dict[str, Any] | None) -> str:
+    normalized_prompt = _normalize_prompt(prompt)
+    if not context:
+        return normalized_prompt
+
+    lines: list[str] = []
+    for key, value in context.items():
+        if value is None:
+            continue
+        value_text = str(value).strip()
+        if value_text:
+            lines.append(f"{key}: {value_text}")
+
+    if not lines:
+        return normalized_prompt
+
+    return f"{normalized_prompt}\n\nContext:\n" + "\n".join(lines)
+
+
+def _set_tool_metadata(tool: Callable[..., str], *, name: str, description: str) -> Callable[..., str]:
+    for attr, value in (
+        ("__name__", name),
+        ("__qualname__", name),
+        ("__doc__", description),
+        ("tool_name", name),
+        ("tool_description", description),
+    ):
+        try:
+            setattr(tool, attr, value)
+        except Exception:
+            pass
+    return tool
+
+
+class _BaseRetentionWriter:
+    agent_name: str = ""
+    persona_instruction: str = ""
+    default_tool_name: str = ""
+
+    def __init__(self) -> None:
+        self.agent = Agent(name=self.agent_name, instructions=self._instructions())
+
+    def _instructions(self) -> str:
+        return (
+            "You write cold sales and customer-retention outreach emails. "
+            "Return exactly one plain-text email body and nothing else. "
+            "Do not include a subject line, HTML, markdown, metadata labels, or commentary. "
+            "Do not mention churn scoring or AI scoring unless explicitly requested in the input. "
+            f"{self.persona_instruction}"
+        )
+
+    def write(self, prompt: str, context: dict[str, Any] | None = None) -> str:
+        composed_input = _compose_input(prompt, context)
+        result = Runner.run_sync(self.agent, composed_input)
+        body = _sanitize_plain_text_body(_final_output_to_text(result))
+        if not body:
+            raise RuntimeError("Writer returned an empty email body")
+        return body
+
+    def as_tool(
+        self,
+        *,
+        tool_name: str | None = None,
+        tool_description: str = TOOL_DESCRIPTION,
+    ) -> Callable[..., str]:
+        writer = self
+        resolved_name = tool_name or self.default_tool_name
+
+        @function_tool
+        def _tool(
+            prompt: str,
+            context: dict[str, Any] | None = None,
+            company_name: str | None = None,
+            from_name: str | None = None,
+            from_email: str | None = None,
+            recipient_name: str | None = None,
+        ) -> str:
+            merged_context = _merge_context(
+                context,
+                company_name=company_name,
+                from_name=from_name,
+                from_email=from_email,
+                recipient_name=recipient_name,
+            )
+            return writer.write(prompt=prompt, context=merged_context)
+
+        return _set_tool_metadata(
+            _tool,
+            name=resolved_name,
+            description=tool_description,
+        )
+
+
+class SeriousRetentionWriter(_BaseRetentionWriter):
+    agent_name = "Serious Retention Writer"
+    persona_instruction = "Tone: professional, empathetic, and provide one clear next step."
+    default_tool_name = "write_retention_email_serious"
+
+
+class WittyRetentionWriter(_BaseRetentionWriter):
+    agent_name = "Witty Retention Writer"
+    persona_instruction = "Tone: warm and lightly witty while remaining professional and practical."
+    default_tool_name = "write_retention_email_witty"
+
+
+class ConciseRetentionWriter(_BaseRetentionWriter):
+    agent_name = "Concise Retention Writer"
+    persona_instruction = "Tone: short, direct, helpful, and action-oriented."
+    default_tool_name = "write_retention_email_concise"
+
+
+write_retention_email_serious = SeriousRetentionWriter().as_tool()
+write_retention_email_witty = WittyRetentionWriter().as_tool()
+write_retention_email_concise = ConciseRetentionWriter().as_tool()
+
+
+__all__ = [
+    "TOOL_DESCRIPTION",
+    "SeriousRetentionWriter",
+    "WittyRetentionWriter",
+    "ConciseRetentionWriter",
+    "write_retention_email_serious",
+    "write_retention_email_witty",
+    "write_retention_email_concise",
+]

--- a/tests/test_retention_writer_tools.py
+++ b/tests/test_retention_writer_tools.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+
+from src.agents import retention_writers
+
+
+class _StubResult:
+    def __init__(self, final_output: str) -> None:
+        self.final_output = final_output
+
+
+class _StubRunner:
+    _OUTPUTS = {
+        "Serious Retention Writer": (
+            "Subject: Retention check-in\n"
+            "<p>Hi there, I wanted to check in and make sure your team is getting full value. "
+            "If you share your top blocker, I can send a concrete plan by Friday.</p>"
+        ),
+        "Witty Retention Writer": (
+            "Subject: Quick reality check\n"
+            "<p>Hi there, no confetti cannon here, just a quick check-in. "
+            "If one thing is making your week harder, tell me and I will fix what I can.</p>"
+        ),
+        "Concise Retention Writer": (
+            "Subject: Fast follow-up\n"
+            "<p>Hi there, quick check-in. Reply with your top issue and I will send next steps today.</p>"
+        ),
+    }
+
+    @staticmethod
+    def run_sync(agent, input_text: str):
+        assert "Write" in input_text
+        return _StubResult(_StubRunner._OUTPUTS[agent.name])
+
+
+def test_retention_writer_tools_construct_with_stable_names():
+    serious_tool = retention_writers.SeriousRetentionWriter().as_tool()
+    witty_tool = retention_writers.WittyRetentionWriter().as_tool()
+    concise_tool = retention_writers.ConciseRetentionWriter().as_tool()
+
+    assert callable(serious_tool)
+    assert callable(witty_tool)
+    assert callable(concise_tool)
+    assert serious_tool.__name__ == "write_retention_email_serious"
+    assert witty_tool.__name__ == "write_retention_email_witty"
+    assert concise_tool.__name__ == "write_retention_email_concise"
+
+
+def test_retention_writer_tools_return_plain_text(monkeypatch):
+    monkeypatch.setattr(retention_writers, "Runner", _StubRunner)
+    tools = [
+        retention_writers.write_retention_email_serious,
+        retention_writers.write_retention_email_witty,
+        retention_writers.write_retention_email_concise,
+    ]
+
+    outputs = [
+        tool(
+            prompt="Write a retention email for at-risk customers",
+            company_name="Example Co",
+            from_name="Customer Success",
+            from_email="success@example.com",
+        )
+        for tool in tools
+    ]
+
+    for body in outputs:
+        assert isinstance(body, str)
+        assert body.strip()
+        assert "<" not in body and ">" not in body
+
+    assert len(set(outputs)) == 3
+
+
+def test_retention_writer_tools_share_exact_description():
+    tools = [
+        retention_writers.write_retention_email_serious,
+        retention_writers.write_retention_email_witty,
+        retention_writers.write_retention_email_concise,
+    ]
+
+    descriptions = {getattr(tool, "tool_description", None) for tool in tools}
+
+    assert descriptions == {retention_writers.TOOL_DESCRIPTION}
+    assert retention_writers.TOOL_DESCRIPTION == "Write a cold sales/retention email"
+
+
+def test_retention_writer_tools_can_run_in_parallel(monkeypatch):
+    monkeypatch.setattr(retention_writers, "Runner", _StubRunner)
+    tools = [
+        retention_writers.write_retention_email_serious,
+        retention_writers.write_retention_email_witty,
+        retention_writers.write_retention_email_concise,
+    ]
+
+    with ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [
+            executor.submit(
+                tool,
+                prompt="Write a retention email for at-risk customers",
+                context={"company_name": "Example Co", "from_name": "Customer Success"},
+            )
+            for tool in tools
+        ]
+        outputs = [future.result() for future in futures]
+
+    assert len(outputs) == 3
+    assert all(isinstance(body, str) and body.strip() for body in outputs)


### PR DESCRIPTION
## What changed

### Added writer agents + tool wrappers
Created `src/agents/retention_writers.py` with three writers and `as_tool(...)` wrappers:

- `SeriousRetentionWriter`
- `WittyRetentionWriter`
- `ConciseRetentionWriter`

Stable tool callables:
- `write_retention_email_serious`
- `write_retention_email_witty`
- `write_retention_email_concise`

All tools share the exact constant description:
- `"Write a cold sales/retention email"`

### Standard output format (plain text only)
Implemented output sanitization to guarantee **plain-text body only**:
- strips HTML tags
- removes `Subject:` prefix (if present)
- returns a `str` suitable for downstream sending

### Optional context support
Tools accept optional context fields for better personalization:
- `context`
- `company_name`
- `from_name`
- `from_email`
- `recipient_name`

### Exports
Exported new writers/tools via `src/agents/__init__.py`.

---

## Tests

Added `tests/test_retention_writer_tools.py` (smoke + behavior checks):

- tools construct/register successfully
- return type is `str`
- output is non-empty
- output contains no HTML tags
- shared identical `tool_description`
- outputs differ by tone (stubbed deterministic runner)
- parallel invocation works (thread pool)

---

## Validation

- `tests/test_retention_writer_tools.py` → **4 passed**
- `pytest -q` → **45 passed, 2 skipped**

✅ Closes PR 5 acceptance criteria: all 3 writer tools can be called in parallel and return 3 plain-text strings.