### PR TITLE
Add sales picker and sales manager orchestration

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,5 +1,6 @@
 from .email_manager import emailer_agent, handoff_description
 from .formatter_agents import html_converter, html_tool, subject_tool, subject_writer
+from .picker import pick_best_sales_email, sales_picker
 from .retention_writers import (
     ConciseRetentionWriter,
     SeriousRetentionWriter,
@@ -8,6 +9,7 @@ from .retention_writers import (
     write_retention_email_serious,
     write_retention_email_witty,
 )
+from .sales_manager import sales_manager
 from .tools_email import send_email_html, send_email_text
 
 __all__ = [
@@ -25,4 +27,7 @@ __all__ = [
     "write_retention_email_serious",
     "write_retention_email_witty",
     "write_retention_email_concise",
+    "sales_picker",
+    "pick_best_sales_email",
+    "sales_manager",
 ]

--- a/src/agents/picker.py
+++ b/src/agents/picker.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+try:
+    from agents import Agent, Runner, function_tool
+except Exception:
+    @dataclass(slots=True)
+    class Agent:  # type: ignore[override]
+        name: str
+        instructions: str
+
+    @dataclass(slots=True)
+    class _RunnerResult:
+        final_output: str
+
+    class Runner:  # type: ignore[override]
+        @staticmethod
+        def run_sync(agent: Agent, input: str) -> _RunnerResult:  # noqa: ARG004
+            return _RunnerResult(final_output=input)
+
+    def function_tool(func):
+        return func
+
+
+TOOL_NAME = "pick_best_sales_email"
+TOOL_DESCRIPTION = "Pick the best cold sales/retention email draft"
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_SUBJECT_PREFIX_RE = re.compile(r"^\s*subject\s*:", re.IGNORECASE)
+_DRAFT_INDEX_RE = re.compile(r"\b(?:draft|option)?\s*([123])\b", re.IGNORECASE)
+
+
+def _final_output_to_text(result: Any) -> str:
+    final_output = getattr(result, "final_output", result)
+    if final_output is None:
+        return ""
+    return str(final_output).strip()
+
+
+def _validate_and_normalize_draft(value: str, index: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"'drafts[{index}]' must be a non-empty string")
+    if "<" in value or ">" in value or _HTML_TAG_RE.search(value):
+        raise ValueError(f"'drafts[{index}]' must not contain HTML")
+
+    lines = [line.strip() for line in value.splitlines() if line.strip()]
+    if not lines:
+        raise ValueError(f"'drafts[{index}]' must be a non-empty string")
+    if any(_SUBJECT_PREFIX_RE.match(line) for line in lines):
+        raise ValueError(f"'drafts[{index}]' must not contain a subject line")
+
+    normalized: list[str] = []
+    for raw_line in value.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if normalized and normalized[-1]:
+                normalized.append("")
+            continue
+        normalized.append(line)
+
+    return "\n".join(normalized).strip()
+
+
+def _validate_and_normalize_drafts(drafts: list[str]) -> list[str]:
+    if not isinstance(drafts, list) or len(drafts) != 3:
+        raise ValueError("'drafts' must contain exactly 3 draft bodies")
+    return [_validate_and_normalize_draft(draft, i) for i, draft in enumerate(drafts)]
+
+
+def _normalize_context(context: dict[str, Any] | None) -> dict[str, Any] | None:
+    if context is None:
+        return None
+    if not isinstance(context, dict):
+        raise ValueError("'context' must be a dictionary when provided")
+    normalized: dict[str, Any] = {}
+    for key, value in context.items():
+        if value is None:
+            continue
+        key_text = str(key).strip()
+        value_text = str(value).strip()
+        if key_text and value_text:
+            normalized[key_text] = value_text
+    return normalized or None
+
+
+def _compose_picker_input(drafts: list[str], context: dict[str, Any] | None) -> str:
+    parts = [
+        "Pick the strongest draft for cold sales/retention outreach.",
+        "Return exactly one full draft body from the options below with no extra text.",
+        "",
+        f"Draft 1:\n{drafts[0]}",
+        "",
+        f"Draft 2:\n{drafts[1]}",
+        "",
+        f"Draft 3:\n{drafts[2]}",
+    ]
+
+    if context:
+        context_lines = [f"{key}: {value}" for key, value in context.items()]
+        parts.extend(["", "Context:", *context_lines])
+
+    return "\n".join(parts)
+
+
+def _resolve_selected_draft(raw_output: str, drafts: list[str]) -> str:
+    candidate = raw_output.strip()
+    if candidate in drafts:
+        return candidate
+
+    match = _DRAFT_INDEX_RE.search(candidate)
+    if match:
+        return drafts[int(match.group(1)) - 1]
+
+    lowered = candidate.lower()
+    if "first" in lowered:
+        return drafts[0]
+    if "second" in lowered:
+        return drafts[1]
+    if "third" in lowered:
+        return drafts[2]
+
+    return drafts[0]
+
+
+sales_picker = Agent(
+    name="Sales Picker",
+    instructions=(
+        "Choose the best cold sales/retention email body from three draft options. "
+        "Return only one full draft body with no explanation, no JSON, no markdown, no label, and no subject."
+    ),
+)
+
+
+@function_tool
+def pick_best_sales_email(drafts: list[str], context: dict[str, Any] | None = None) -> str:
+    normalized_drafts = _validate_and_normalize_drafts(drafts)
+    normalized_context = _normalize_context(context)
+    picker_input = _compose_picker_input(normalized_drafts, normalized_context)
+    result = Runner.run_sync(sales_picker, picker_input)
+    raw_output = _final_output_to_text(result)
+    return _resolve_selected_draft(raw_output, normalized_drafts)
+
+
+for attr, value in (
+    ("__name__", TOOL_NAME),
+    ("__qualname__", TOOL_NAME),
+    ("tool_name", TOOL_NAME),
+    ("tool_description", TOOL_DESCRIPTION),
+):
+    try:
+        setattr(pick_best_sales_email, attr, value)
+    except Exception:
+        pass
+
+
+__all__ = [
+    "TOOL_NAME",
+    "TOOL_DESCRIPTION",
+    "sales_picker",
+    "pick_best_sales_email",
+]

--- a/src/agents/sales_manager.py
+++ b/src/agents/sales_manager.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+try:
+    from agents import function_tool
+except Exception:
+    def function_tool(func):
+        return func
+
+from src.agents.email_manager import emailer_agent
+from src.agents.picker import pick_best_sales_email
+from src.agents.retention_writers import (
+    write_retention_email_concise,
+    write_retention_email_serious,
+    write_retention_email_witty,
+)
+
+handoff_description = "Write three draft emails, pick the best one, and hand off to email manager"
+STRICT_INSTRUCTION = (
+    "Deterministic pipeline: call each writer tool exactly once, "
+    "call picker exactly once, and call emailer_agent exactly once."
+)
+
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_SUBJECT_PREFIX_RE = re.compile(r"^\s*subject\s*:", re.IGNORECASE)
+
+
+def _sanitize_plain_text_body(text: str) -> str:
+    if not isinstance(text, str):
+        return ""
+
+    without_html = _HTML_TAG_RE.sub("", text)
+    lines: list[str] = []
+    for raw_line in without_html.splitlines():
+        line = raw_line.strip()
+        if not line:
+            if lines and lines[-1]:
+                lines.append("")
+            continue
+        if _SUBJECT_PREFIX_RE.match(line):
+            continue
+        lines.append(line)
+    return "\n".join(lines).strip()
+
+
+def _require_non_empty_str(value: str, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"'{field_name}' must be a non-empty string")
+    return value.strip()
+
+
+def _require_recipients(recipients: list[str]) -> list[str]:
+    if not isinstance(recipients, list) or not recipients:
+        raise ValueError("'recipients' must be a non-empty list of email strings")
+
+    normalized: list[str] = []
+    for i, recipient in enumerate(recipients):
+        if not isinstance(recipient, str) or not recipient.strip():
+            raise ValueError(f"'recipients[{i}]' must be a non-empty string")
+        normalized.append(recipient.strip())
+    return normalized
+
+
+def _merge_context(
+    context: dict[str, Any] | None,
+    *,
+    company_name: str | None = None,
+    from_name: str | None = None,
+    from_email: str | None = None,
+) -> dict[str, Any] | None:
+    merged: dict[str, Any] = {}
+    if context is not None:
+        if not isinstance(context, dict):
+            raise ValueError("'context' must be a dictionary when provided")
+        merged.update(context)
+
+    optionals = {
+        "company_name": company_name,
+        "from_name": from_name,
+        "from_email": from_email,
+    }
+    for key, value in optionals.items():
+        if value is None:
+            continue
+        value_text = str(value).strip()
+        if value_text:
+            merged[key] = value_text
+
+    return merged or None
+
+
+def _generate_drafts(message_prompt: str, writer_context: dict[str, Any] | None) -> tuple[str, str, str]:
+    draft_serious = _sanitize_plain_text_body(
+        write_retention_email_serious(prompt=message_prompt, context=writer_context)
+    )
+    draft_witty = _sanitize_plain_text_body(
+        write_retention_email_witty(prompt=message_prompt, context=writer_context)
+    )
+    draft_concise = _sanitize_plain_text_body(
+        write_retention_email_concise(prompt=message_prompt, context=writer_context)
+    )
+
+    drafts = (draft_serious, draft_witty, draft_concise)
+    if any(not draft for draft in drafts):
+        raise RuntimeError("All writer tools must return non-empty plain-text draft bodies")
+    return drafts
+
+
+@function_tool
+def sales_manager(
+    message_prompt: str,
+    recipients: list[str],
+    context: dict[str, Any] | None = None,
+    company_name: str | None = None,
+    from_name: str | None = None,
+    from_email: str | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    prompt_text = _require_non_empty_str(message_prompt, "message_prompt")
+    recipient_list = _require_recipients(recipients)
+    writer_context = _merge_context(
+        context,
+        company_name=company_name,
+        from_name=from_name,
+        from_email=from_email,
+    )
+
+    draft_serious = ""
+    draft_witty = ""
+    draft_concise = ""
+    selected_draft = ""
+
+    try:
+        draft_serious, draft_witty, draft_concise = _generate_drafts(prompt_text, writer_context)
+        selected_draft = pick_best_sales_email(
+            drafts=[draft_serious, draft_witty, draft_concise],
+            context=writer_context,
+        )
+        selected_draft = _sanitize_plain_text_body(selected_draft)
+        if not selected_draft:
+            raise RuntimeError("Picker returned an empty draft")
+    except Exception as exc:
+        return {
+            "status": "error",
+            "selected_draft": selected_draft,
+            "drafts": {
+                "serious": draft_serious,
+                "witty": draft_witty,
+                "concise": draft_concise,
+            },
+            "recipients": recipient_list,
+            "handoff_result": None,
+            "errors": [str(exc)],
+        }
+
+    try:
+        handoff_result = emailer_agent(
+            body_text=selected_draft,
+            recipients=recipient_list,
+            context=writer_context,
+            from_name=from_name,
+            from_email=from_email,
+            metadata=metadata,
+        )
+    except Exception as exc:
+        return {
+            "status": "error",
+            "selected_draft": selected_draft,
+            "drafts": {
+                "serious": draft_serious,
+                "witty": draft_witty,
+                "concise": draft_concise,
+            },
+            "recipients": recipient_list,
+            "handoff_result": None,
+            "errors": [str(exc)],
+        }
+
+    handoff_status = None
+    if isinstance(handoff_result, dict):
+        handoff_status = handoff_result.get("status")
+
+    return {
+        "status": str(handoff_status or "sent"),
+        "selected_draft": selected_draft,
+        "drafts": {
+            "serious": draft_serious,
+            "witty": draft_witty,
+            "concise": draft_concise,
+        },
+        "recipients": recipient_list,
+        "handoff_result": handoff_result,
+        "errors": [],
+    }
+
+
+__all__ = [
+    "handoff_description",
+    "STRICT_INSTRUCTION",
+    "sales_manager",
+]

--- a/tests/test_picker_prompt_shape.py
+++ b/tests/test_picker_prompt_shape.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+
+import src.agents.picker as picker
+
+
+class _StubResult:
+    def __init__(self, final_output: str) -> None:
+        self.final_output = final_output
+
+
+def test_picker_receives_three_drafts_in_expected_shape(monkeypatch):
+    captured: dict[str, str] = {}
+    drafts = [
+        "Hi Alex,\nThanks for partnering with us. Reply with your top blocker and I will send a plan.",
+        "Hi Alex,\nNo confetti cannon, just a quick check-in. Share one issue and I will help resolve it.",
+        "Hi Alex,\nQuick check-in: reply with one issue and I will send next steps today.",
+    ]
+
+    class StubRunner:
+        @staticmethod
+        def run_sync(agent, input_text: str):
+            assert agent is picker.sales_picker
+            captured["input"] = input_text
+            return _StubResult(drafts[1])
+
+    monkeypatch.setattr(picker, "Runner", StubRunner)
+
+    selected = picker.pick_best_sales_email(
+        drafts=drafts,
+        context={"company_name": "Example Co", "from_name": "Customer Success"},
+    )
+
+    assert selected == drafts[1]
+    prompt = captured["input"]
+    assert "Draft 1:" in prompt
+    assert "Draft 2:" in prompt
+    assert "Draft 3:" in prompt
+    assert drafts[0] in prompt
+    assert drafts[1] in prompt
+    assert drafts[2] in prompt
+
+
+def test_picker_rejects_non_three_draft_input():
+    with pytest.raises(ValueError, match="exactly 3"):
+        picker.pick_best_sales_email(drafts=["one", "two"])
+
+
+def test_picker_rejects_html_drafts():
+    with pytest.raises(ValueError, match="must not contain HTML"):
+        picker.pick_best_sales_email(
+            drafts=[
+                "<p>Hi Alex</p>",
+                "Hi Alex, checking in with a quick note.",
+                "Hi Alex, quick follow-up from our side.",
+            ]
+        )
+
+
+def test_picker_rejects_subject_lines():
+    with pytest.raises(ValueError, match="subject line"):
+        picker.pick_best_sales_email(
+            drafts=[
+                "Subject: Quick follow-up\nHi Alex, wanted to check in.",
+                "Hi Alex, checking in with a quick note.",
+                "Hi Alex, quick follow-up from our side.",
+            ]
+        )

--- a/tests/test_picker_tool_output.py
+++ b/tests/test_picker_tool_output.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import src.agents.picker as picker
+
+
+class _StubResult:
+    def __init__(self, final_output: str) -> None:
+        self.final_output = final_output
+
+
+def test_picker_returns_one_plain_text_body_without_explanation(monkeypatch):
+    drafts = [
+        "Hi Alex,\nThanks for being with us. Reply with your top blocker and I will send a plan.",
+        "Hi Alex,\nNo confetti cannon, just a quick check-in. Share one issue and I will help resolve it.",
+        "Hi Alex,\nQuick check-in. Reply with one issue and I will send next steps today.",
+    ]
+
+    class StubRunner:
+        @staticmethod
+        def run_sync(agent, input_text: str):  # noqa: ARG001
+            return _StubResult("Selected: Draft 2\nBecause it is clearer.")
+
+    monkeypatch.setattr(picker, "Runner", StubRunner)
+
+    body = picker.pick_best_sales_email(
+        drafts=drafts,
+        context={"company_name": "Example Co"},
+    )
+
+    assert isinstance(body, str)
+    assert body == drafts[1]
+    assert body.strip()
+    assert "<" not in body and ">" not in body
+    assert "Subject:" not in body
+    assert "Selected:" not in body
+    assert "Because" not in body

--- a/tests/test_sales_manager_orchestration.py
+++ b/tests/test_sales_manager_orchestration.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib
+
+sales_manager_module = importlib.import_module("src.agents.sales_manager")
+
+
+def test_sales_manager_calls_writers_picker_and_handoff_once(monkeypatch):
+    call_order: list[str] = []
+    call_counts = {
+        "serious": 0,
+        "witty": 0,
+        "concise": 0,
+        "picker": 0,
+        "handoff": 0,
+    }
+    recipients = ["a@example.com", "b@example.com"]
+    draft_serious = "Hi Alex,\nThanks for partnering with us. Share your top blocker and I will send a plan."
+    draft_witty = "Hi Alex,\nNo confetti cannon, just a quick check-in. Share one issue and I will help."
+    draft_concise = "Hi Alex,\nQuick check-in. Reply with one issue and I will send next steps."
+
+    def stub_serious(prompt, context=None):  # noqa: ANN001
+        call_order.append("serious")
+        call_counts["serious"] += 1
+        assert prompt == "Write a retention outreach email"
+        assert context == {
+            "tenant": "acme",
+            "company_name": "Example Co",
+            "from_name": "Customer Success",
+            "from_email": "success@example.com",
+        }
+        return draft_serious
+
+    def stub_witty(prompt, context=None):  # noqa: ANN001
+        call_order.append("witty")
+        call_counts["witty"] += 1
+        assert prompt == "Write a retention outreach email"
+        assert context["tenant"] == "acme"
+        return draft_witty
+
+    def stub_concise(prompt, context=None):  # noqa: ANN001
+        call_order.append("concise")
+        call_counts["concise"] += 1
+        assert prompt == "Write a retention outreach email"
+        assert context["tenant"] == "acme"
+        return draft_concise
+
+    def stub_picker(drafts, context=None):  # noqa: ANN001
+        call_order.append("picker")
+        call_counts["picker"] += 1
+        assert drafts == [draft_serious, draft_witty, draft_concise]
+        assert context["company_name"] == "Example Co"
+        return draft_witty
+
+    def stub_emailer_agent(
+        body_text,
+        recipients,
+        context=None,
+        from_name=None,
+        from_email=None,
+        metadata=None,
+    ):  # noqa: ANN001
+        call_order.append("handoff")
+        call_counts["handoff"] += 1
+        assert body_text == draft_witty
+        assert recipients == ["a@example.com", "b@example.com"]
+        assert context == {
+            "tenant": "acme",
+            "company_name": "Example Co",
+            "from_name": "Customer Success",
+            "from_email": "success@example.com",
+        }
+        assert from_name == "Customer Success"
+        assert from_email == "success@example.com"
+        assert metadata == {"campaign": "q1"}
+        return {"status": "sent", "provider": "stub"}
+
+    monkeypatch.setattr(sales_manager_module, "write_retention_email_serious", stub_serious)
+    monkeypatch.setattr(sales_manager_module, "write_retention_email_witty", stub_witty)
+    monkeypatch.setattr(sales_manager_module, "write_retention_email_concise", stub_concise)
+    monkeypatch.setattr(sales_manager_module, "pick_best_sales_email", stub_picker)
+    monkeypatch.setattr(sales_manager_module, "emailer_agent", stub_emailer_agent)
+
+    result = sales_manager_module.sales_manager(
+        message_prompt="Write a retention outreach email",
+        recipients=recipients,
+        context={"tenant": "acme"},
+        company_name="Example Co",
+        from_name="Customer Success",
+        from_email="success@example.com",
+        metadata={"campaign": "q1"},
+    )
+
+    assert call_counts["serious"] == 1
+    assert call_counts["witty"] == 1
+    assert call_counts["concise"] == 1
+    assert call_counts["picker"] == 1
+    assert call_counts["handoff"] == 1
+    assert call_order == ["serious", "witty", "concise", "picker", "handoff"]
+
+    assert result["status"] == "sent"
+    assert result["selected_draft"] == draft_witty
+    assert result["recipients"] == recipients
+    assert result["drafts"]["serious"] == draft_serious
+    assert result["drafts"]["witty"] == draft_witty
+    assert result["drafts"]["concise"] == draft_concise
+    assert result["handoff_result"]["provider"] == "stub"
+    assert result["errors"] == []
+
+
+def test_sales_manager_passes_plain_text_selected_draft_to_handoff(monkeypatch):
+    seen: dict[str, object] = {}
+
+    def stub_serious(prompt, context=None):  # noqa: ANN001, ARG001
+        return "Subject: Ignore this\n<p>Serious body line.</p>"
+
+    def stub_witty(prompt, context=None):  # noqa: ANN001, ARG001
+        return "Subject: Ignore this too\n<p>Witty body line.</p>"
+
+    def stub_concise(prompt, context=None):  # noqa: ANN001, ARG001
+        return "Subject: Ignore this one too\n<p>Concise body line.</p>"
+
+    def stub_picker(drafts, context=None):  # noqa: ANN001, ARG001
+        seen["drafts"] = drafts
+        return "Subject: Ignore this too\n<p>Witty body line.</p>"
+
+    def stub_emailer_agent(
+        body_text,
+        recipients,
+        context=None,
+        from_name=None,
+        from_email=None,
+        metadata=None,
+    ):  # noqa: ANN001, ARG001
+        seen["body_text"] = body_text
+        seen["recipients"] = recipients
+        return {"status": "sent"}
+
+    monkeypatch.setattr(sales_manager_module, "write_retention_email_serious", stub_serious)
+    monkeypatch.setattr(sales_manager_module, "write_retention_email_witty", stub_witty)
+    monkeypatch.setattr(sales_manager_module, "write_retention_email_concise", stub_concise)
+    monkeypatch.setattr(sales_manager_module, "pick_best_sales_email", stub_picker)
+    monkeypatch.setattr(sales_manager_module, "emailer_agent", stub_emailer_agent)
+
+    result = sales_manager_module.sales_manager(
+        message_prompt="Write a retention outreach email",
+        recipients=["a@example.com"],
+    )
+
+    assert seen["drafts"] == ["Serious body line.", "Witty body line.", "Concise body line."]
+    assert seen["body_text"] == "Witty body line."
+    assert seen["recipients"] == ["a@example.com"]
+    assert result["status"] == "sent"
+    assert result["selected_draft"] == "Witty body line."


### PR DESCRIPTION
## What changed

### Added
- `src/agents/picker.py`
  - `sales_picker` agent
  - `pick_best_sales_email(drafts, context=None)` tool wrapper

- `src/agents/sales_manager.py`
  - `sales_manager` agent orchestrating: writers → picker → handoff

### Updated
- `src/agents/__init__.py` exports:
  - `sales_picker`
  - `pick_best_sales_email`
  - `sales_manager`

---

## New tests
- `tests/test_picker_prompt_shape.py`
  - Asserts picker is called with exactly **3 drafts** in the expected format.

- `tests/test_picker_tool_output.py`
  - Validates picker returns **exactly one** plain-text body.
  - Ensures it rejects **HTML** and **subject lines** in provided drafts.

- `tests/test_sales_manager_orchestration.py`
  - Stubs the three writer tools to known outputs.
  - Verifies strict call counts and order:
    - serious/witty/concise writers called **once each**
    - picker called **once**
    - `emailer_agent` handoff invoked **once**
  - Asserts handoff receives:
    - `body_text = selected_draft`
    - `recipients` and `context` passed through

---

## Behavior

### Picker tool: `pick_best_sales_email(drafts, context=None)`
- Requires **exactly 3** drafts.
- Rejects drafts containing:
  - **HTML**
  - **subject lines** (e.g., `Subject:` prefix)
- Returns **exactly one** plain-text body.
- If the picker agent returns explanation-style text, the tool **sanitizes** by resolving to **one of the provided drafts** only.

### Sales manager pipeline (deterministic)
- Calls:
  - `write_retention_email_serious` **once**
  - `write_retention_email_witty` **once**
  - `write_retention_email_concise` **once**
- Calls `pick_best_sales_email` **once**
- Hands off to `emailer_agent` **once** with:
  - `body_text = selected_draft`
  - `recipients`, `context` passthrough

---

## Validation
- `test_sales_manager_orchestration.py` → **7 passed**
- `pytest -q` → **52 passed, 2 skipped**