### PR TITLE
feat(api): add /api/outreach outreach pipeline with safety guards

### DIFF
--- a/application.py
+++ b/application.py
@@ -1,7 +1,8 @@
 from flask import Flask, request, render_template, jsonify
-from datetime import datetime
+from datetime import datetime, timezone
 import json
 import os
+import re
 
 import pandas as pd
 
@@ -12,6 +13,13 @@ from src.decisioning import (
     recommended_action,
 )
 from src.pipeline.prediction_pipeline import CustomData, PredictPipeline
+from src.agents.formatter_agents import subject_tool as outreach_subject_tool
+from src.agents.retention_writers import (
+    write_retention_email_concise,
+    write_retention_email_serious,
+    write_retention_email_witty,
+)
+from src.agents.tools_email import send_email_text
 from src.services.prediction_service import (
     MAX_BATCH_SIZE,
     REQUIRED_FIELDS,
@@ -70,6 +78,15 @@ BATCH_UI_SAMPLE_CSV_OPTIONS = json.dumps(BATCH_UI_SAMPLE_PAYLOAD["options"], ind
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 ARTIFACTS_DIR = os.path.join(PROJECT_ROOT, "artifacts")
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+OUTREACH_CONTRACT_VERSION = "v1"
+DEFAULT_OUTREACH_THRESHOLD = 0.65
+MAX_EMAILS_PER_REQUEST = 50
+DEFAULT_OUTREACH_MAX_EMAILS = 50
+DEFAULT_OUTREACH_DRY_RUN = True
+DEFAULT_OUTREACH_TONE = "serious"
+VALID_OUTREACH_TONES = {"serious", "witty", "concise"}
 
 REQUIRED_ARTIFACTS = [
     os.path.join(ARTIFACTS_DIR, "schema.json"),
@@ -195,6 +212,364 @@ def execute_batch_prediction(records, options):
 
     http_status = 400 if response_body.get("status") == "error" else 200
     return jsonify(response_body), http_status
+
+
+def _timestamp_utc() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _outreach_send_block() -> dict:
+    return {"attempted": False, "sent": 0, "results": []}
+
+
+def _outreach_summary(
+    *,
+    n_records: int,
+    n_valid: int,
+    n_invalid: int,
+    n_selected: int,
+    threshold: float,
+    max_emails: int,
+    dry_run: bool,
+) -> dict:
+    return {
+        "n_records": int(n_records),
+        "n_valid": int(n_valid),
+        "n_invalid": int(n_invalid),
+        "n_selected": int(n_selected),
+        "threshold": float(threshold),
+        "max_emails": int(max_emails),
+        "dry_run": bool(dry_run),
+    }
+
+
+def _outreach_envelope(
+    *,
+    status: str,
+    summary: dict,
+    selected: list | None = None,
+    send: dict | None = None,
+    errors: list | None = None,
+) -> dict:
+    return {
+        "contract_version": OUTREACH_CONTRACT_VERSION,
+        "status": status,
+        "summary": summary,
+        "selected": selected or [],
+        "send": send or _outreach_send_block(),
+        "errors": errors or [],
+        "timestamp": _timestamp_utc(),
+    }
+
+
+def _normalize_email(value):
+    if not isinstance(value, str):
+        return None
+    email = value.strip().lower()
+    if not email:
+        return None
+    if not _EMAIL_RE.match(email):
+        return None
+    return email
+
+
+def _coerce_probability(value):
+    try:
+        p_churn = float(value)
+    except (TypeError, ValueError):
+        return None
+    if p_churn < 0 or p_churn > 1:
+        return None
+    return p_churn
+
+
+def _coerce_positive_int(value):
+    try:
+        int_value = int(value)
+    except (TypeError, ValueError):
+        return None
+    if int_value <= 0:
+        return None
+    return int_value
+
+
+def _extract_record_id(record, fallback_index):
+    if not isinstance(record, dict):
+        return f"idx-{fallback_index}"
+
+    for key in ("id", "customer_id", "row_id"):
+        if key in record and record.get(key) is not None and str(record.get(key)).strip():
+            return str(record.get(key)).strip()
+    return f"idx-{fallback_index}"
+
+
+def _writer_for_tone(tone):
+    writers = {
+        "serious": write_retention_email_serious,
+        "witty": write_retention_email_witty,
+        "concise": write_retention_email_concise,
+    }
+    return writers[tone]
+
+
+def _build_outreach_prompt(
+    *,
+    tone: str,
+    company_name: str,
+    from_name: str,
+    recipient_id: str,
+    recipient_email: str,
+    p_churn: float,
+):
+    return (
+        f"Write a {tone} retention outreach email from {from_name} at {company_name} "
+        f"to customer {recipient_id} ({recipient_email}). "
+        f"Customer churn probability is {p_churn:.2f}. "
+        "Do not mention scoring. Include one clear next step."
+    )
+
+
+def _sendgrid_ready():
+    api_key = str(os.getenv("SENDGRID_API_KEY", "")).strip()
+    return bool(api_key)
+
+
+def _send_result_ok(send_result):
+    if isinstance(send_result, dict):
+        if "ok" in send_result:
+            return bool(send_result.get("ok"))
+        status_code = send_result.get("status_code")
+        if status_code is not None:
+            try:
+                return 200 <= int(status_code) < 300
+            except (TypeError, ValueError):
+                return False
+    return bool(send_result)
+
+
+def _select_outreach_recipients(
+    *,
+    batch_results,
+    records,
+    threshold,
+    max_emails,
+):
+    ranked = []
+    errors = []
+    for row_position, result in enumerate(batch_results):
+        if not isinstance(result, dict):
+            continue
+
+        p_churn = _coerce_probability(result.get("p_churn"))
+        if p_churn is None or p_churn < threshold:
+            continue
+
+        try:
+            index = int(result.get("index", row_position))
+        except (TypeError, ValueError):
+            errors.append(
+                {
+                    "stage": "targeting",
+                    "row_index": row_position,
+                    "message": "Result index is invalid and row was skipped",
+                }
+            )
+            continue
+        if index < 0 or index >= len(records):
+            errors.append(
+                {
+                    "stage": "targeting",
+                    "row_index": row_position,
+                    "message": "Result index is out of range and row was skipped",
+                }
+            )
+            continue
+
+        record = records[index]
+        email = _normalize_email(result.get("email"))
+        if email is None and isinstance(record, dict):
+            email = _normalize_email(record.get("email"))
+        if email is None:
+            errors.append(
+                {
+                    "stage": "targeting",
+                    "row_index": index,
+                    "id": result.get("id") or _extract_record_id(record, index),
+                    "message": "Selected row is missing a valid 'email'",
+                }
+            )
+            continue
+
+        record_id = result.get("id")
+        if record_id is None or not str(record_id).strip():
+            record_id = _extract_record_id(record, index)
+        else:
+            record_id = str(record_id).strip()
+
+        ranked.append(
+            {
+                "id": record_id,
+                "index": index,
+                "email": email,
+                "p_churn": p_churn,
+            }
+        )
+
+    ranked.sort(key=lambda item: (-item["p_churn"], item["index"], item["id"]))
+    return ranked[:max_emails], errors
+
+
+def _parse_outreach_request(body):
+    errors = []
+
+    if not isinstance(body, dict):
+        return None, [{"stage": "request", "message": "JSON body must be an object"}]
+
+    if body.get("contract_version") != OUTREACH_CONTRACT_VERSION:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "contract_version",
+                "message": "contract_version must be 'v1'",
+            }
+        )
+
+    records = body.get("records")
+    if not isinstance(records, list) or not records:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "records",
+                "message": "records must be a non-empty list",
+            }
+        )
+        records = []
+    elif len(records) > MAX_BATCH_SIZE:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "records",
+                "message": f"Batch size exceeds MAX_BATCH_SIZE ({MAX_BATCH_SIZE})",
+            }
+        )
+
+    outreach_options = body.get("outreach_options", {})
+    if not isinstance(outreach_options, dict):
+        errors.append(
+            {
+                "stage": "request",
+                "field": "outreach_options",
+                "message": "outreach_options must be an object",
+            }
+        )
+        outreach_options = {}
+
+    threshold = _coerce_probability(outreach_options.get("threshold", DEFAULT_OUTREACH_THRESHOLD))
+    if threshold is None:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "outreach_options.threshold",
+                "message": "threshold must be a number between 0 and 1",
+            }
+        )
+        threshold = DEFAULT_OUTREACH_THRESHOLD
+
+    max_emails = _coerce_positive_int(outreach_options.get("max_emails", DEFAULT_OUTREACH_MAX_EMAILS))
+    if max_emails is None:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "outreach_options.max_emails",
+                "message": "max_emails must be an integer greater than 0",
+            }
+        )
+        max_emails = DEFAULT_OUTREACH_MAX_EMAILS
+    elif max_emails > MAX_EMAILS_PER_REQUEST:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "outreach_options.max_emails",
+                "message": f"max_emails exceeds MAX_EMAILS_PER_REQUEST ({MAX_EMAILS_PER_REQUEST})",
+            }
+        )
+
+    dry_run = outreach_options.get("dry_run", DEFAULT_OUTREACH_DRY_RUN)
+    if not isinstance(dry_run, bool):
+        errors.append(
+            {
+                "stage": "request",
+                "field": "outreach_options.dry_run",
+                "message": "dry_run must be a boolean",
+            }
+        )
+        dry_run = DEFAULT_OUTREACH_DRY_RUN
+
+    tone_raw = outreach_options.get("tone", DEFAULT_OUTREACH_TONE)
+    tone = str(tone_raw).strip().lower()
+    if tone not in VALID_OUTREACH_TONES:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "outreach_options.tone",
+                "message": "tone must be one of: serious, witty, concise",
+            }
+        )
+        tone = DEFAULT_OUTREACH_TONE
+
+    context = body.get("context")
+    if not isinstance(context, dict):
+        errors.append(
+            {
+                "stage": "request",
+                "field": "context",
+                "message": "context must be an object",
+            }
+        )
+        context = {}
+
+    company_name = str(context.get("company_name", "")).strip()
+    if not company_name:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "context.company_name",
+                "message": "context.company_name must be a non-empty string",
+            }
+        )
+
+    from_name = str(context.get("from_name", "")).strip()
+    if not from_name:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "context.from_name",
+                "message": "context.from_name must be a non-empty string",
+            }
+        )
+
+    from_email_raw = context.get("from_email")
+    from_email = _normalize_email(from_email_raw)
+    if from_email is None:
+        errors.append(
+            {
+                "stage": "request",
+                "field": "context.from_email",
+                "message": "context.from_email must be a valid email address",
+            }
+        )
+
+    parsed = {
+        "records": records,
+        "threshold": threshold,
+        "max_emails": max_emails,
+        "dry_run": dry_run,
+        "tone": tone,
+        "company_name": company_name,
+        "from_name": from_name,
+        "from_email": from_email,
+    }
+    return parsed, errors
 
 
 # -----------------------------
@@ -343,6 +718,277 @@ def predict_batch_csv_api():
         return batch_contract_error(str(exc), status_code=400)
 
     return execute_batch_prediction(records, options)
+
+
+@app.route("/api/outreach", methods=["POST"])
+def outreach_api():
+    if not request.is_json:
+        summary = _outreach_summary(
+            n_records=0,
+            n_valid=0,
+            n_invalid=0,
+            n_selected=0,
+            threshold=DEFAULT_OUTREACH_THRESHOLD,
+            max_emails=DEFAULT_OUTREACH_MAX_EMAILS,
+            dry_run=DEFAULT_OUTREACH_DRY_RUN,
+        )
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=[{"stage": "request", "message": "Content-Type must be application/json"}],
+        )
+        return jsonify(response_body), 415
+
+    body = request.get_json(silent=True)
+    if body is None:
+        summary = _outreach_summary(
+            n_records=0,
+            n_valid=0,
+            n_invalid=0,
+            n_selected=0,
+            threshold=DEFAULT_OUTREACH_THRESHOLD,
+            max_emails=DEFAULT_OUTREACH_MAX_EMAILS,
+            dry_run=DEFAULT_OUTREACH_DRY_RUN,
+        )
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=[{"stage": "request", "message": "Invalid JSON body"}],
+        )
+        return jsonify(response_body), 400
+
+    parsed, validation_errors = _parse_outreach_request(body)
+    if parsed is None:
+        summary = _outreach_summary(
+            n_records=0,
+            n_valid=0,
+            n_invalid=0,
+            n_selected=0,
+            threshold=DEFAULT_OUTREACH_THRESHOLD,
+            max_emails=DEFAULT_OUTREACH_MAX_EMAILS,
+            dry_run=DEFAULT_OUTREACH_DRY_RUN,
+        )
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=validation_errors,
+        )
+        return jsonify(response_body), 400
+
+    n_records = len(parsed["records"])
+    summary = _outreach_summary(
+        n_records=n_records,
+        n_valid=0,
+        n_invalid=n_records,
+        n_selected=0,
+        threshold=parsed["threshold"],
+        max_emails=parsed["max_emails"],
+        dry_run=parsed["dry_run"],
+    )
+    if validation_errors:
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=validation_errors,
+        )
+        status_code = 413 if any("MAX_BATCH_SIZE" in error.get("message", "") for error in validation_errors) else 400
+        return jsonify(response_body), status_code
+
+    if not artifacts_ready():
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=[
+                {
+                    "stage": "predict",
+                    "message": "Model artifacts are not ready yet. Please wait for training to finish.",
+                }
+            ],
+        )
+        return jsonify(response_body), 503
+
+    errors = []
+    try:
+        batch_response = predict_batch_records(parsed["records"], {"mode": "partial"})
+    except ValueError as exc:
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=[{"stage": "predict", "message": str(exc)}],
+        )
+        return jsonify(response_body), 400
+    except Exception as exc:
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=[{"stage": "predict", "message": f"Internal server error: {str(exc)}"}],
+        )
+        return jsonify(response_body), 500
+
+    results = batch_response.get("results")
+    if not isinstance(results, list):
+        response_body = _outreach_envelope(
+            status="error",
+            summary=summary,
+            errors=[
+                {
+                    "stage": "predict",
+                    "message": "Batch response is missing a valid 'results' list",
+                }
+            ],
+        )
+        return jsonify(response_body), 500
+
+    batch_summary = batch_response.get("summary") if isinstance(batch_response.get("summary"), dict) else {}
+    n_valid = int(batch_summary.get("valid_records", len(results)))
+    n_invalid = int(batch_summary.get("invalid_records", max(0, n_records - n_valid)))
+
+    raw_batch_errors = batch_response.get("errors")
+    if isinstance(raw_batch_errors, list):
+        for item in raw_batch_errors:
+            errors.append({"stage": "batch_validation", "detail": item})
+    elif raw_batch_errors is not None:
+        errors.append({"stage": "batch_validation", "detail": raw_batch_errors})
+
+    selected, target_errors = _select_outreach_recipients(
+        batch_results=results,
+        records=parsed["records"],
+        threshold=parsed["threshold"],
+        max_emails=parsed["max_emails"],
+    )
+    errors.extend(target_errors)
+
+    drafted_selected = []
+    writer = _writer_for_tone(parsed["tone"])
+    writer_context = {
+        "company_name": parsed["company_name"],
+        "from_name": parsed["from_name"],
+        "from_email": parsed["from_email"],
+    }
+    for recipient in selected:
+        prompt = _build_outreach_prompt(
+            tone=parsed["tone"],
+            company_name=parsed["company_name"],
+            from_name=parsed["from_name"],
+            recipient_id=str(recipient["id"]),
+            recipient_email=str(recipient["email"]),
+            p_churn=float(recipient["p_churn"]),
+        )
+        try:
+            body_text = str(writer(prompt=prompt, context=writer_context)).strip()
+            if not body_text:
+                raise ValueError("writer returned an empty draft")
+            subject = str(outreach_subject_tool(body_text)).strip()
+            if not subject:
+                subject = f"{parsed['company_name']} check-in"
+        except Exception as exc:
+            errors.append(
+                {
+                    "stage": "draft",
+                    "id": recipient["id"],
+                    "email": recipient["email"],
+                    "message": str(exc),
+                }
+            )
+            continue
+
+        drafted_selected.append(
+            {
+                "id": recipient["id"],
+                "index": recipient["index"],
+                "email": recipient["email"],
+                "p_churn": recipient["p_churn"],
+                "draft": {
+                    "subject": subject,
+                    "body_text": body_text,
+                },
+            }
+        )
+
+    send_report = _outreach_send_block()
+    if not parsed["dry_run"] and drafted_selected:
+        if not _sendgrid_ready():
+            errors.append(
+                {
+                    "stage": "send",
+                    "message": "SENDGRID_API_KEY is required when dry_run is false",
+                }
+            )
+        else:
+            send_report["attempted"] = True
+            sent_count = 0
+            send_results = []
+            for recipient in drafted_selected:
+                try:
+                    send_result = send_email_text(
+                        subject=recipient["draft"]["subject"],
+                        body_text=recipient["draft"]["body_text"],
+                        to_emails=[recipient["email"]],
+                        from_email=parsed["from_email"],
+                    )
+                    sent_ok = _send_result_ok(send_result)
+                    if sent_ok:
+                        sent_count += 1
+                    else:
+                        errors.append(
+                            {
+                                "stage": "send",
+                                "id": recipient["id"],
+                                "email": recipient["email"],
+                                "message": "Email provider reported a failed send attempt",
+                            }
+                        )
+                    send_results.append(
+                        {
+                            "id": recipient["id"],
+                            "email": recipient["email"],
+                            "ok": sent_ok,
+                            "result": send_result,
+                        }
+                    )
+                except Exception as exc:
+                    errors.append(
+                        {
+                            "stage": "send",
+                            "id": recipient["id"],
+                            "email": recipient["email"],
+                            "message": str(exc),
+                        }
+                    )
+                    send_results.append(
+                        {
+                            "id": recipient["id"],
+                            "email": recipient["email"],
+                            "ok": False,
+                            "error": str(exc),
+                        }
+                    )
+
+            send_report["sent"] = sent_count
+            send_report["results"] = send_results
+
+    summary = _outreach_summary(
+        n_records=n_records,
+        n_valid=n_valid,
+        n_invalid=n_invalid,
+        n_selected=len(drafted_selected),
+        threshold=parsed["threshold"],
+        max_emails=parsed["max_emails"],
+        dry_run=parsed["dry_run"],
+    )
+    status = "ok"
+    if errors:
+        status = "partial" if n_valid > 0 else "error"
+
+    response_body = _outreach_envelope(
+        status=status,
+        summary=summary,
+        selected=drafted_selected,
+        send=send_report,
+        errors=errors,
+    )
+    status_code = 200 if status != "error" else 400
+    return jsonify(response_body), status_code
 
 
 @app.route("/predictbatch", methods=["GET", "POST"])

--- a/tests/test_api_outreach.py
+++ b/tests/test_api_outreach.py
@@ -1,0 +1,279 @@
+import application
+
+
+def valid_record(customer_id: str, email: str):
+    return {
+        "customer_id": customer_id,
+        "email": email,
+        "CreditScore": 619,
+        "Geography": "France",
+        "Gender": "Female",
+        "Age": 42,
+        "Tenure": 2,
+        "Balance": 0,
+        "NumOfProducts": 1,
+        "HasCrCard": 1,
+        "IsActiveMember": 1,
+        "EstimatedSalary": 101348.88,
+    }
+
+
+def test_outreach_contract_validation_failure_short_circuits_pipeline(monkeypatch):
+    calls = {"predict": 0, "send": 0}
+
+    def stub_predict_batch_records(records, options):  # noqa: ANN001, ARG001
+        calls["predict"] += 1
+        return {}
+
+    def stub_send_email_text(**kwargs):  # noqa: ANN003, ARG001
+        calls["send"] += 1
+        return {"status_code": 202, "ok": True}
+
+    monkeypatch.setattr(application, "predict_batch_records", stub_predict_batch_records)
+    monkeypatch.setattr(application, "send_email_text", stub_send_email_text)
+
+    client = application.app.test_client()
+    payload = {
+        "contract_version": "v2",
+        "records": [],
+        "outreach_options": {
+            "threshold": 2,
+            "max_emails": 0,
+            "dry_run": "yes",
+            "tone": "playful",
+        },
+        "context": {},
+    }
+
+    response = client.post("/api/outreach", json=payload)
+
+    assert response.status_code == 400
+    body = response.get_json()
+    assert body["contract_version"] == "v1"
+    assert body["status"] == "error"
+    assert body["selected"] == []
+    assert body["send"] == {"attempted": False, "sent": 0, "results": []}
+    assert body["summary"]["n_records"] == 0
+    assert body["errors"]
+    assert calls["predict"] == 0
+    assert calls["send"] == 0
+
+
+def test_outreach_dry_run_returns_drafts_and_never_sends(monkeypatch):
+    predict_calls = {"count": 0}
+    send_calls = {"count": 0}
+
+    def stub_predict_batch_records(records, options):  # noqa: ANN001, ARG001
+        predict_calls["count"] += 1
+        return {
+            "status": "success",
+            "results": [
+                {"index": 1, "id": "C002", "p_churn": 0.72},
+                {"index": 0, "id": "C001", "p_churn": 0.91},
+                {"index": 2, "id": "C003", "p_churn": 0.30},
+            ],
+            "errors": None,
+            "summary": {"valid_records": 3, "invalid_records": 0},
+        }
+
+    def stub_witty_writer(prompt, context=None):  # noqa: ANN001, ARG001
+        return "Quick check-in from your retention team."
+
+    def stub_subject_tool(draft_text):  # noqa: ANN001
+        return "We'd love to keep you"
+
+    def stub_send_email_text(**kwargs):  # noqa: ANN003, ARG001
+        send_calls["count"] += 1
+        return {"status_code": 202, "ok": True}
+
+    monkeypatch.setattr(application, "artifacts_ready", lambda: True)
+    monkeypatch.setattr(application, "predict_batch_records", stub_predict_batch_records)
+    monkeypatch.setattr(application, "write_retention_email_witty", stub_witty_writer)
+    monkeypatch.setattr(application, "outreach_subject_tool", stub_subject_tool)
+    monkeypatch.setattr(application, "send_email_text", stub_send_email_text)
+
+    client = application.app.test_client()
+    payload = {
+        "contract_version": "v1",
+        "records": [
+            valid_record("C001", "one@example.com"),
+            valid_record("C002", "two@example.com"),
+            valid_record("C003", "three@example.com"),
+        ],
+        "outreach_options": {
+            "threshold": 0.65,
+            "max_emails": 50,
+            "dry_run": True,
+            "tone": "witty",
+        },
+        "context": {
+            "company_name": "Example Co",
+            "from_name": "Retention Team",
+            "from_email": "retention@example.com",
+        },
+    }
+
+    response = client.post("/api/outreach", json=payload)
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "ok"
+    assert body["summary"]["n_records"] == 3
+    assert body["summary"]["n_valid"] == 3
+    assert body["summary"]["n_invalid"] == 0
+    assert body["summary"]["n_selected"] == 2
+    assert [item["id"] for item in body["selected"]] == ["C001", "C002"]
+    assert all("draft" in item for item in body["selected"])
+    assert all(set(item["draft"]) == {"subject", "body_text"} for item in body["selected"])
+    assert body["send"] == {"attempted": False, "sent": 0, "results": []}
+    assert body["errors"] == []
+    assert predict_calls["count"] == 1
+    assert send_calls["count"] == 0
+
+
+def test_outreach_send_mode_caps_and_sends_exactly_max_emails(monkeypatch):
+    predict_calls = {"count": 0}
+    send_calls = {"count": 0}
+    sent_recipients = []
+
+    def stub_predict_batch_records(records, options):  # noqa: ANN001, ARG001
+        predict_calls["count"] += 1
+        return {
+            "status": "success",
+            "results": [
+                {"index": 0, "id": "C001", "p_churn": 0.99},
+                {"index": 1, "id": "C002", "p_churn": 0.87},
+                {"index": 2, "id": "C003", "p_churn": 0.79},
+            ],
+            "errors": None,
+            "summary": {"valid_records": 3, "invalid_records": 0},
+        }
+
+    def stub_serious_writer(prompt, context=None):  # noqa: ANN001, ARG001
+        return "We value your business and want to help."
+
+    def stub_subject_tool(draft_text):  # noqa: ANN001
+        return "A quick support check-in"
+
+    def stub_send_email_text(subject, body_text, to_emails, from_email=None):  # noqa: ANN001
+        send_calls["count"] += 1
+        sent_recipients.extend(to_emails)
+        return {"status_code": 202, "ok": True, "subject": subject, "from_email": from_email}
+
+    monkeypatch.setenv("SENDGRID_API_KEY", "sg.test-key")
+    monkeypatch.setattr(application, "artifacts_ready", lambda: True)
+    monkeypatch.setattr(application, "predict_batch_records", stub_predict_batch_records)
+    monkeypatch.setattr(application, "write_retention_email_serious", stub_serious_writer)
+    monkeypatch.setattr(application, "outreach_subject_tool", stub_subject_tool)
+    monkeypatch.setattr(application, "send_email_text", stub_send_email_text)
+
+    client = application.app.test_client()
+    payload = {
+        "contract_version": "v1",
+        "records": [
+            valid_record("C001", "one@example.com"),
+            valid_record("C002", "two@example.com"),
+            valid_record("C003", "three@example.com"),
+        ],
+        "outreach_options": {
+            "threshold": 0.7,
+            "max_emails": 2,
+            "dry_run": False,
+            "tone": "serious",
+        },
+        "context": {
+            "company_name": "Example Co",
+            "from_name": "Retention Team",
+            "from_email": "retention@example.com",
+        },
+    }
+
+    response = client.post("/api/outreach", json=payload)
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "ok"
+    assert body["summary"]["n_selected"] == 2
+    assert [item["id"] for item in body["selected"]] == ["C001", "C002"]
+    assert body["send"]["attempted"] is True
+    assert body["send"]["sent"] == 2
+    assert len(body["send"]["results"]) == 2
+    assert predict_calls["count"] == 1
+    assert send_calls["count"] == 2
+    assert sent_recipients == ["one@example.com", "two@example.com"]
+
+
+def test_outreach_response_contract_shape_is_stable_across_modes(monkeypatch):
+    def stub_predict_batch_records(records, options):  # noqa: ANN001, ARG001
+        return {
+            "status": "success",
+            "results": [{"index": 0, "id": "C001", "p_churn": 0.91}],
+            "errors": None,
+            "summary": {"valid_records": 1, "invalid_records": 0},
+        }
+
+    def stub_writer(prompt, context=None):  # noqa: ANN001, ARG001
+        return "We appreciate your business."
+
+    def stub_subject_tool(draft_text):  # noqa: ANN001, ARG001
+        return "Checking in"
+
+    def stub_send_email_text(subject, body_text, to_emails, from_email=None):  # noqa: ANN001, ARG001
+        return {"status_code": 202, "ok": True}
+
+    monkeypatch.setenv("SENDGRID_API_KEY", "sg.test-key")
+    monkeypatch.setattr(application, "artifacts_ready", lambda: True)
+    monkeypatch.setattr(application, "predict_batch_records", stub_predict_batch_records)
+    monkeypatch.setattr(application, "write_retention_email_concise", stub_writer)
+    monkeypatch.setattr(application, "outreach_subject_tool", stub_subject_tool)
+    monkeypatch.setattr(application, "send_email_text", stub_send_email_text)
+
+    client = application.app.test_client()
+    base_payload = {
+        "contract_version": "v1",
+        "records": [valid_record("C001", "one@example.com")],
+        "outreach_options": {
+            "threshold": 0.65,
+            "max_emails": 1,
+            "tone": "concise",
+        },
+        "context": {
+            "company_name": "Example Co",
+            "from_name": "Retention Team",
+            "from_email": "retention@example.com",
+        },
+    }
+
+    dry_run_payload = dict(base_payload)
+    dry_run_payload["outreach_options"] = dict(base_payload["outreach_options"])
+    dry_run_payload["outreach_options"]["dry_run"] = True
+
+    send_payload = dict(base_payload)
+    send_payload["outreach_options"] = dict(base_payload["outreach_options"])
+    send_payload["outreach_options"]["dry_run"] = False
+
+    dry_run_response = client.post("/api/outreach", json=dry_run_payload)
+    send_response = client.post("/api/outreach", json=send_payload)
+
+    assert dry_run_response.status_code == 200
+    assert send_response.status_code == 200
+
+    dry_body = dry_run_response.get_json()
+    send_body = send_response.get_json()
+
+    expected_top_keys = {"contract_version", "status", "summary", "selected", "send", "errors", "timestamp"}
+    expected_summary_keys = {"n_records", "n_valid", "n_invalid", "n_selected", "threshold", "max_emails", "dry_run"}
+    expected_send_keys = {"attempted", "sent", "results"}
+    expected_selected_keys = {"id", "index", "email", "p_churn", "draft"}
+    expected_draft_keys = {"subject", "body_text"}
+
+    assert set(dry_body) == expected_top_keys
+    assert set(send_body) == expected_top_keys
+    assert set(dry_body["summary"]) == expected_summary_keys
+    assert set(send_body["summary"]) == expected_summary_keys
+    assert set(dry_body["send"]) == expected_send_keys
+    assert set(send_body["send"]) == expected_send_keys
+    assert set(dry_body["selected"][0]) == expected_selected_keys
+    assert set(send_body["selected"][0]) == expected_selected_keys
+    assert set(dry_body["selected"][0]["draft"]) == expected_draft_keys
+    assert set(send_body["selected"][0]["draft"]) == expected_draft_keys


### PR DESCRIPTION

Expose the complete churn → targeting → drafting → (optional) sending workflow via a safe and testable HTTP endpoint.

This enables operational outreach directly from the API while enforcing strict safety controls.

---

## ✅ What Was Implemented

### New Endpoint

`POST /api/outreach`

This endpoint:

1. Validates request contract (strict schema + caps)
2. Runs batch prediction (single model call)
3. Selects recipients based on `p_churn >= threshold`
4. Sorts descending by probability
5. Caps to `max_emails`
6. Generates tone-based drafts (serious | witty | concise)
7. Optionally sends emails (guarded)

---

## 🔧 Changes

### `application.py`

- Added outreach request parsing and strict contract validation
- Enforced hard caps (`MAX_BATCH_SIZE`, `max_emails`)
- Added stable outreach response envelope:
  - `contract_version`
  - `status`
  - `summary`
  - `selected`
  - `send`
  - `errors`
  - `timestamp`
- Implemented recipient targeting flow:
  - `p_churn >= threshold`
  - sort descending
  - cap to `max_emails`
- Implemented tone-based draft generation:
  - `serious`
  - `witty`
  - `concise`
- Added subject generation integration
- Implemented guarded send path:
  - `dry_run` defaults to `true`
  - no send if none selected
  - requires `SENDGRID_API_KEY` for send mode
- Added route: `POST /api/outreach`

---

## 🔐 Safety Controls

- `dry_run = true` by default
- Hard cap on `max_emails`
- Hard cap on batch size
- No send if:
  - contract validation fails
  - zero recipients selected
  - SendGrid env not configured
- Stable response envelope across dry-run and send modes

Prevents accidental bulk sends and production blast risk.

---

## 🧪 Tests Added

### `tests/test_api_outreach.py`

Covered:

- Contract validation failures short-circuit pipeline
- Dry-run:
  - returns selected recipients
  - returns generated drafts
  - does NOT call send tool
- Non-dry-run:
  - enforces `max_emails`
  - calls send tool exact number of times
- Response shape stability across dry-run and send modes

---

## 📊 Validation
